### PR TITLE
Global task balance 3.6.2-tl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ target/
 build/
 build_eclipse/
 out/
+bin/
+/*bin
 .gradle/
 .vscode/
 lib_managed/

--- a/GLOBAL_BALANCE_TASK_ASSIGNOR_BEHAVIOR.md
+++ b/GLOBAL_BALANCE_TASK_ASSIGNOR_BEHAVIOR.md
@@ -1,6 +1,22 @@
-# Kafka Connect Distributed Mode - Global Task Assignor Behavior
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
 
-This document describes task allocation behavior for Kafka Connect in distributed mode across 4 scenarios, demonstrating worker-to-task assignments with strict balance requirements.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Kafka Connect Distributed Mode - Global Balance Task Assignor Behavior
+
+This document describes task allocation behavior for Kafka Connect in distributed mode across 4 scenarios, demonstrating worker-to-task assignments with strict balance requirements. The number of Workers, Consumer Groups and Tasks for those Consumer Groups are an example. The acutal behavior for GlobalBalanceTaskAssignor should be capable of handling any number of Workers, Consumer Groups and Tasks.
 
 ## Balance Requirements
 
@@ -23,13 +39,13 @@ This document describes task allocation behavior for Kafka Connect in distribute
 
 ---
 
-## Scenario 1: Initial Allocation (Starting Unassigned State)
+## Scenario 1: Initial Allocation New Consumer Group Deployment
 
 ### Description
-New consumer group deployment with no pre-existing task assignments. Tasks are allocated evenly among all available worker nodes.
+A new consumer group deployment with no pre-existing task assignments. Tasks are allocated evenly among all available worker nodes.
 
 ### Behavior
-- Allocate equal number of tasks among all 5 available worker nodes
+- Allocate equal number of tasks among all available worker nodes, in this example 5
 - Per-consumer task count difference ≤ 1
 - Overall total tasks difference per worker ≤ 1
 
@@ -73,27 +89,7 @@ All consumers have maximum difference of 1 task across workers.
 
 ---
 
-## Scenario 2: Consumer Config Change / Redeployment
-
-### Description
-Configuration change or redeployment event for existing consumer groups.
-
-### Behavior
-- Trigger redeploy ensuring balance is retained in the same worker nodes
-- Worker-to-task affinity is retained
-- No task movement needed (deployment already balanced)
-
-### Before State
-5 Workers (W1-W5) with task allocation from Scenario 1.
-
-### After State
-5 Workers (W1-W5) - **Identical to Scenario 1**
-
-**No changes to task allocation. Worker-to-task affinity maintained.**
-
----
-
-## Scenario 3: Worker Scale Down Event
+## Scenario 2: Worker Scale Down Event
 
 ### Description
 Worker scale down event where 2 nodes are removed from the cluster (W4 and W5).
@@ -147,7 +143,7 @@ Tasks from W4 (12 tasks) and W5 (12 tasks) were redistributed to W1, W2, and W3,
 
 ---
 
-## Scenario 4: Worker Scale Up Event
+## Scenario 3: Worker Scale Up Event
 
 ### Description
 Worker scale up event where 3 new nodes are added to the cluster (W4, W5, W6).
@@ -215,6 +211,25 @@ All consumers maintain maximum difference of 1 task across workers.
 Rebalancing prioritizes consumers with highest task counts (C1 → C2 → C3) to minimize disruption while ensuring both per-consumer and global balance constraints are satisfied.
 
 ---
+
+## Scenario 4: Catch All & Consumer Config Change / Update
+
+### Description
+Catch all logic as well as for configuration changes or redeployment event for existing consumer groups.
+
+### Behavior
+- Trigger a full rebalance across all workers consumers and tasks ensuring balance is enforced
+- Per-Consumer Balance: Task count difference across workers ≤ 1 for each consumer group
+- Global Balance: Total task count difference across workers ≤ 1
+
+### Before State
+6 Workers (W1-W6) with task allocation from Scenario 3.
+
+### After State
+6 Workers (W1-W6) - **Balanced Workloads**
+
+---
+
 
 ## Summary
 

--- a/README_GLOBAL_BALANCE_ASSIGNOR_BEHAVIOR.md
+++ b/README_GLOBAL_BALANCE_ASSIGNOR_BEHAVIOR.md
@@ -1,0 +1,228 @@
+# Kafka Connect Distributed Mode - Global Task Assignor Behavior
+
+This document describes task allocation behavior for Kafka Connect in distributed mode across 4 scenarios, demonstrating worker-to-task assignments with strict balance requirements.
+
+## Balance Requirements
+
+1. **Per-Consumer Balance:** Task count difference across workers ≤ 1 for each consumer group
+2. **Global Balance:** Total task count difference across workers ≤ 1
+
+## Baseline Configuration
+
+**Consumer Groups and Task Counts:**
+
+| Consumer | Tasks |
+|----------|-------|
+| C1 | 18 |
+| C2 | 11 |
+| C3 | 7 |
+| C4, C5, C6 | 4 each |
+| C7, C8 | 3 each |
+| C9-C14 | 1 each |
+| **Total** | **60** |
+
+---
+
+## Scenario 1: Initial Allocation (Starting Unassigned State)
+
+### Description
+New consumer group deployment with no pre-existing task assignments. Tasks are allocated evenly among all available worker nodes.
+
+### Behavior
+- Allocate equal number of tasks among all 5 available worker nodes
+- Per-consumer task count difference ≤ 1
+- Overall total tasks difference per worker ≤ 1
+
+### Before State
+No tasks assigned.
+
+### After State: 5 Workers (W1-W5)
+
+**Worker Load Summary:**
+- W1: 12 tasks
+- W2: 12 tasks
+- W3: 12 tasks
+- W4: 12 tasks
+- W5: 12 tasks
+- **Global Balance: Perfect (difference = 0)**
+
+### Task Allocation Matrix
+
+| Worker | C1 | C2 | C3 | C4 | C5 | C6 | C7 | C8 | C9 | C10 | C11 | C12 | C13 | C14 | **Total** |
+|--------|----|----|----|----|----|----|----|----|----|----|----|----|----|----|-----------|
+| **W1** | C1-T1, C1-T2, C1-T3, C1-T4 | C2-T6, C2-T7 | C3-T3, C3-T4 | - | C5-T1 | C6-T2 | C7-T3 | - | - | C10-T1 | - | - | - | - | **12** |
+| **W2** | C1-T5, C1-T6, C1-T7, C1-T8 | C2-T8, C2-T9 | C3-T5 | C4-T1 | C5-T2 | C6-T3 | - | C8-T1 | - | - | C11-T1 | - | - | - | **12** |
+| **W3** | C1-T9, C1-T10, C1-T11, C1-T12 | C2-T10, C2-T11 | C3-T6 | C4-T2 | C5-T3 | C6-T4 | - | C8-T2 | - | - | - | C12-T1 | - | - | **12** |
+| **W4** | C1-T13, C1-T14, C1-T15 | C2-T1, C2-T2, C2-T3 | C3-T7 | C4-T3 | C5-T4 | - | C7-T1 | C8-T3 | - | - | - | - | C13-T1 | - | **12** |
+| **W5** | C1-T16, C1-T17, C1-T18 | C2-T4, C2-T5 | C3-T1, C3-T2 | C4-T4 | - | C6-T1 | C7-T2 | - | C9-T1 | - | - | - | - | C14-T1 | **12** |
+
+### Balance Verification
+
+**Per-Consumer Distribution:**
+- C1: [4, 4, 4, 3, 3] ✓
+- C2: [2, 2, 2, 3, 2] ✓
+- C3: [2, 1, 1, 1, 2] ✓
+- C4: [0, 1, 1, 1, 1] ✓
+- C5: [1, 1, 1, 1, 0] ✓
+- C6: [1, 1, 1, 0, 1] ✓
+- C7: [1, 0, 0, 1, 1] ✓
+- C8: [0, 1, 1, 1, 0] ✓
+- C9-C14: Single task, difference ≤ 1 ✓
+
+All consumers have maximum difference of 1 task across workers.
+
+---
+
+## Scenario 2: Consumer Config Change / Redeployment
+
+### Description
+Configuration change or redeployment event for existing consumer groups.
+
+### Behavior
+- Trigger redeploy ensuring balance is retained in the same worker nodes
+- Worker-to-task affinity is retained
+- No task movement needed (deployment already balanced)
+
+### Before State
+5 Workers (W1-W5) with task allocation from Scenario 1.
+
+### After State
+5 Workers (W1-W5) - **Identical to Scenario 1**
+
+**No changes to task allocation. Worker-to-task affinity maintained.**
+
+---
+
+## Scenario 3: Worker Scale Down Event
+
+### Description
+Worker scale down event where 2 nodes are removed from the cluster (W4 and W5).
+
+### Behavior
+- Rebalance only the unassigned tasks from removed workers
+- Assume assigned tasks on remaining workers (W1, W2, W3) are already balanced
+- Allocate among remaining nodes in a balanced way
+- No task count difference > 1 for each consumer across all worker nodes
+- Overall total tasks difference per worker ≤ 1
+- Existing workload on W1, W2, W3 is preserved
+
+### Before State
+5 Workers (W1-W5) from Scenario 1.
+
+### After State: 3 Workers (W1-W3)
+
+**Workers Removed:** W4, W5
+
+**Worker Load Summary:**
+- W1: 20 tasks
+- W2: 20 tasks
+- W3: 20 tasks
+- **Global Balance: Perfect (difference = 0)**
+
+### Task Allocation Matrix
+
+| Worker | C1 | C2 | C3 | C4 | C5 | C6 | C7 | C8 | C9 | C10 | C11 | C12 | C13 | C14 | **Total** |
+|--------|----|----|----|----|----|----|----|----|----|----|----|----|----|----|-----------|
+| **W1** | C1-T1, C1-T2, C1-T3, C1-T4, C1-T13, C1-T16 | C2-T6, C2-T7, C2-T1, C2-T4 | C3-T3, C3-T4, C3-T2 | C4-T3 | C5-T1 | C6-T2 | C7-T3 | C8-T3 | C9-T1 | C10-T1 | - | - | - | - | **20** |
+| **W2** | C1-T5, C1-T6, C1-T7, C1-T8, C1-T14, C1-T17 | C2-T8, C2-T9, C2-T2, C2-T5 | C3-T5, C3-T1 | C4-T1 | C5-T2, C5-T4 | C6-T3 | C7-T1 | C8-T1 | - | - | C11-T1 | - | C13-T1 | - | **20** |
+| **W3** | C1-T9, C1-T10, C1-T11, C1-T12, C1-T15, C1-T18 | C2-T10, C2-T11, C2-T3 | C3-T6, C3-T7 | C4-T2, C4-T4 | C5-T3 | C6-T4, C6-T1 | C7-T2 | C8-T2 | - | - | - | C12-T1 | - | C14-T1 | **20** |
+
+### Balance Verification
+
+**Per-Consumer Distribution:**
+- C1: [6, 6, 6] (diff=0) ✓
+- C2: [4, 4, 3] (diff=1) ✓
+- C3: [3, 2, 2] (diff=1) ✓
+- C4: [1, 1, 2] (diff=1) ✓
+- C5: [1, 2, 1] (diff=1) ✓
+- C6: [1, 1, 2] (diff=1) ✓
+- C7: [1, 1, 1] (diff=0) ✓
+- C8: [1, 1, 1] (diff=0) ✓
+- C9-C14: Single task, difference ≤ 1 ✓
+
+All consumers maintain maximum difference of 1 task across workers.
+
+### Task Redistribution Details
+Tasks from W4 (12 tasks) and W5 (12 tasks) were redistributed to W1, W2, and W3, maintaining perfect balance.
+
+---
+
+## Scenario 4: Worker Scale Up Event
+
+### Description
+Worker scale up event where 3 new nodes are added to the cluster (W4, W5, W6).
+
+### Behavior
+- At all times, task difference for each consumer group ≤ 1 among all workers
+- Only trigger rebalance for consumer groups with task count > number of workers
+- Allocate equal amount of tasks on each node (difference ≤ 1)
+- Overall total tasks difference per worker ≤ 1
+- Sort consumers by task.max count and prioritize highest task count consumers
+- Revoke and move only the minimum required number of tasks to create balanced distribution
+
+### Before State
+3 Workers (W1-W3) from Scenario 3.
+
+### After State: 6 Workers (W1-W6)
+
+**Workers Added:** W4, W5, W6
+
+**Worker Load Summary:**
+- W1: 10 tasks
+- W2: 10 tasks
+- W3: 10 tasks
+- W4: 10 tasks
+- W5: 10 tasks
+- W6: 10 tasks
+- **Global Balance: Perfect (difference = 0)**
+
+### Task Allocation Matrix
+
+| Worker | C1 | C2 | C3 | C4 | C5 | C6 | C7 | C8 | C9 | C10 | C11 | C12 | C13 | C14 | **Total** |
+|--------|----|----|----|----|----|----|----|----|----|----|----|----|----|----|-----------|
+| **W1** | C1-T1, C1-T2, C1-T3 | C2-T1, C2-T2 | C3-T3 | C4-T1 | C5-T3 | - | C7-T1 | - | C9-T1 | - | - | - | - | - | **10** |
+| **W2** | C1-T4, C1-T5, C1-T6 | C2-T3, C2-T4 | C3-T4 | C4-T2 | C5-T4 | - | C7-T2 | - | - | C10-T1 | - | - | - | - | **10** |
+| **W3** | C1-T7, C1-T8, C1-T9 | C2-T5, C2-T6 | C3-T5 | C4-T3 | - | C6-T1 | C7-T3 | - | - | - | C11-T1 | - | - | - | **10** |
+| **W4** | C1-T10, C1-T11, C1-T12 | C2-T7, C2-T8 | C3-T6 | C4-T4 | - | C6-T2 | - | C8-T1 | - | - | - | C12-T1 | - | - | **10** |
+| **W5** | C1-T13, C1-T14, C1-T15 | C2-T9, C2-T10 | C3-T7 | - | C5-T1 | C6-T3 | - | C8-T2 | - | - | - | - | C13-T1 | - | **10** |
+| **W6** | C1-T16, C1-T17, C1-T18 | C2-T11 | C3-T1, C3-T2 | - | C5-T2 | C6-T4 | - | C8-T3 | - | - | - | - | - | C14-T1 | **10** |
+
+### Balance Verification
+
+**Per-Consumer Distribution:**
+- C1: [3, 3, 3, 3, 3, 3] (diff=0) ✓
+- C2: [2, 2, 2, 2, 2, 1] (diff=1) ✓
+- C3: [1, 1, 1, 1, 1, 2] (diff=1) ✓
+- C4: [1, 1, 1, 1, 0, 0] (diff=1) ✓
+- C5: [1, 1, 0, 0, 1, 1] (diff=1) ✓
+- C6: [0, 0, 1, 1, 1, 1] (diff=1) ✓
+- C7: [1, 1, 1, 0, 0, 0] (diff=1) ✓
+- C8: [0, 0, 0, 1, 1, 1] (diff=1) ✓
+- C9-C14: Single task, difference ≤ 1 ✓
+
+All consumers maintain maximum difference of 1 task across workers.
+
+### Rebalancing Details
+
+**Consumers Requiring Rebalance (task count > 6):**
+- C1 (18 tasks): Rebalanced from [6, 6, 6, 0, 0, 0] to [3, 3, 3, 3, 3, 3]
+- C2 (11 tasks): Rebalanced from [4, 4, 3, 0, 0, 0] to [2, 2, 2, 2, 2, 1]
+- C3 (7 tasks): Rebalanced from [3, 2, 2, 0, 0, 0] to [1, 1, 1, 1, 1, 2]
+
+**Consumers Not Requiring Rebalance (task count ≤ 6):**
+- C4-C14: Tasks redistributed to achieve global balance
+
+Rebalancing prioritizes consumers with highest task counts (C1 → C2 → C3) to minimize disruption while ensuring both per-consumer and global balance constraints are satisfied.
+
+---
+
+## Summary
+
+This implementation ensures:
+
+1. ✅ **Strict Balance Enforcement:** Task count difference never exceeds 1 (per-consumer and globally)
+2. ✅ **Affinity Preservation:** Worker-to-task relationships retained during config changes (Scenario 2)
+3. ✅ **Minimal Disruption:** Only unassigned tasks rebalanced during scale-down (Scenario 3)
+4. ✅ **Intelligent Scale-Up:** Selective rebalancing for high-task consumers during scale-up (Scenario 4)
+5. ✅ **Global Optimization:** Total workload distributed evenly across all workers in all scenarios
+

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -157,6 +157,9 @@
     <suppress checks="NPathComplexity"
               files="(DistributedHerder|RestClient|RestServer|JsonConverter|KafkaConfigBackingStore|FileStreamSourceTask|WorkerSourceTask|TopicAdmin).java"/>
 
+    <suppress checks="(CyclomaticComplexity|MethodLength|JavaNCSS|NPathComplexity)"
+              files="GlobalBalanceTaskAssignor.java"/>
+
     <!-- connect tests-->
     <suppress checks="ClassDataAbstractionCoupling"
               files="(DistributedHerder|KafkaBasedLog|WorkerSourceTaskWithTopicCreation|WorkerSourceTask)Test.java"/>

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -182,6 +182,17 @@ public class DistributedConfig extends WorkerConfig {
             + "period the connectors and tasks of the departed workers remain unassigned";
     public static final int SCHEDULED_REBALANCE_MAX_DELAY_MS_DEFAULT = Math.toIntExact(TimeUnit.SECONDS.toMillis(300));
 
+    /**
+     * <code>enable.global.balance.task.assignor</code>
+     */
+    public static final String ENABLE_GLOBAL_BALANCE_TASK_ASSIGNOR_CONFIG = "enable.global.balance.task.assignor";
+    public static final String ENABLE_GLOBAL_BALANCE_TASK_ASSIGNOR_DOC = "Enable the global balance task assignor "
+            + "which ensures strict per-consumer and global balance requirements: "
+            + "1) Task count difference across workers ≤ 1 for each consumer group; "
+            + "2) Total task count difference across workers ≤ 1. "
+            + "When enabled, this assignor provides better load distribution compared to the default incremental cooperative assignor.";
+    public static final boolean ENABLE_GLOBAL_BALANCE_TASK_ASSIGNOR_DEFAULT = false;
+
     public static final String INTER_WORKER_KEY_GENERATION_ALGORITHM_CONFIG = "inter.worker.key.generation.algorithm";
     public static final String INTER_WORKER_KEY_GENERATION_ALGORITHM_DEFAULT = "HmacSHA256";
     public static final String INTER_WORKER_KEY_GENERATION_ALGORITHM_DOC = "The algorithm to use for generating internal request keys. "
@@ -469,6 +480,11 @@ public class DistributedConfig extends WorkerConfig {
                     between(0, Integer.MAX_VALUE),
                     ConfigDef.Importance.LOW,
                     SCHEDULED_REBALANCE_MAX_DELAY_MS_DOC)
+            .define(ENABLE_GLOBAL_BALANCE_TASK_ASSIGNOR_CONFIG,
+                    ConfigDef.Type.BOOLEAN,
+                    ENABLE_GLOBAL_BALANCE_TASK_ASSIGNOR_DEFAULT,
+                    ConfigDef.Importance.MEDIUM,
+                    ENABLE_GLOBAL_BALANCE_TASK_ASSIGNOR_DOC)
             .define(INTER_WORKER_KEY_TTL_MS_CONFIG,
                     ConfigDef.Type.INT,
                     INTER_WORKER_KEY_TTL_MS_MS_DEFAULT,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/GlobalBalanceTaskAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/GlobalBalanceTaskAssignor.java
@@ -1,0 +1,1113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.distributed;
+
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.runtime.distributed.WorkerCoordinator.ConnectorsAndTasks;
+import org.apache.kafka.connect.runtime.distributed.WorkerCoordinator.WorkerLoad;
+import org.apache.kafka.connect.storage.ClusterConfigState;
+import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+/**
+ * An assignor that extends the IncrementalCooperativeAssignor to provide global balance task assignment.
+ * 
+ * This assignor ensures strict balance requirements:
+ * 1. Per-Consumer Balance: Task count difference across workers ≤ 1 for each consumer group
+ * 2. Global Balance: Total task count difference across workers ≤ 1
+ * 
+ * The assignor handles four main scenarios:
+ * 1. Initial allocation (from unassigned state)
+ * 2. Configuration changes (maintains affinity)
+ * 3. Worker scale down (redistributes from removed workers)
+ * 4. Worker scale up (rebalances high-task consumers)
+ * 
+ * @see <a href="https://github.com/triplelift-internal/kafka/blob/3.6.2-tl/GLOBAL_BALANCE_TASK_ASSIGNOR_BEHAVIOR.md">
+ * Global Balance Task Assignor Behavior Documentation</a>
+ */
+public class GlobalBalanceTaskAssignor extends IncrementalCooperativeAssignor {
+    private final Logger log;
+
+    // For testing
+    ClusterConfigState configSnapshot;
+
+    public GlobalBalanceTaskAssignor(LogContext logContext, Time time, int maxDelay) {
+        super(logContext, time, maxDelay);
+        this.log = logContext.logger(GlobalBalanceTaskAssignor.class);
+    }
+
+    @Override
+    protected void assignConnectors(List<WorkerLoad> workerAssignment, Collection<String> connectors) {
+        if (connectors.isEmpty()) {
+            return;
+        }
+
+        log.debug("Globally balancing {} connectors across {} workers", connectors.size(), workerAssignment.size());
+        
+        // Group connectors by their consumer group (extract from connector name)
+        Map<String, List<String>> connectorsByConsumer = groupConnectorsByConsumer(connectors);
+        
+        // Sort consumers by connector count (descending) to prioritize high-count consumers
+        List<String> sortedConsumers = connectorsByConsumer.keySet().stream()
+                .sorted(Comparator.comparingInt((String consumer) -> connectorsByConsumer.get(consumer).size()).reversed())
+                .collect(Collectors.toList());
+
+        // Apply global balance assignment for each consumer group
+        for (String consumer : sortedConsumers) {
+            List<String> consumerConnectors = connectorsByConsumer.get(consumer);
+            assignConnectorsWithGlobalBalance(workerAssignment, consumerConnectors);
+        }
+    }
+
+    @Override
+    protected void assignTasks(List<WorkerLoad> workerAssignment, Collection<ConnectorTaskId> tasks) {
+        if (tasks.isEmpty()) {
+            return;
+        }
+
+        log.debug("Globally balancing {} tasks across {} workers", tasks.size(), workerAssignment.size());
+        
+        // Group tasks by their consumer group (extract from connector name)
+        Map<String, List<ConnectorTaskId>> tasksByConsumer = groupTasksByConsumer(tasks);
+        
+        // Sort consumers by task count (descending) to prioritize high-count consumers
+        List<String> sortedConsumers = tasksByConsumer.keySet().stream()
+                .sorted(Comparator.comparingInt((String consumer) -> tasksByConsumer.get(consumer).size()).reversed())
+                .collect(Collectors.toList());
+
+        // Apply global balance assignment for each consumer group
+        for (String consumer : sortedConsumers) {
+            List<ConnectorTaskId> consumerTasks = tasksByConsumer.get(consumer);
+            assignTasksWithGlobalBalance(workerAssignment, consumerTasks);
+        }
+    }
+
+    /**
+     * Groups connectors by their consumer group identifier.
+     * Assumes connector names follow pattern: consumer-connector-name
+     */
+    private Map<String, List<String>> groupConnectorsByConsumer(Collection<String> connectors) {
+        Map<String, List<String>> result = new TreeMap<>();
+        
+        for (String connector : connectors) {
+            String consumer = extractConsumerFromConnector(connector);
+            result.computeIfAbsent(consumer, k -> new ArrayList<>()).add(connector);
+        }
+        
+        return result;
+    }
+
+    /**
+     * Groups tasks by their consumer group identifier.
+     * Assumes connector names follow pattern: consumer-connector-name
+     */
+    private Map<String, List<ConnectorTaskId>> groupTasksByConsumer(Collection<ConnectorTaskId> tasks) {
+        Map<String, List<ConnectorTaskId>> result = new TreeMap<>();
+        
+        for (ConnectorTaskId task : tasks) {
+            String consumer = extractConsumerFromConnector(task.connector());
+            result.computeIfAbsent(consumer, k -> new ArrayList<>()).add(task);
+        }
+        
+        return result;
+    }
+
+    /**
+     * Extracts consumer group identifier from connector configuration.
+     * Uses the connector's "name" config value with "connect-" prefix.
+     * e.g., connector with name "s3-sink-ctv_usage" -> "connect-s3-sink-ctv_usage"
+     */
+    protected String extractConsumerFromConnector(String connectorName) {
+        if (configSnapshot != null) {
+            Map<String, String> connectorConfig = configSnapshot.connectorConfig(connectorName);
+            if (connectorConfig != null) {
+                String name = connectorConfig.get("name");
+                if (name != null && !name.isEmpty()) {
+                    return "connect-" + name;
+                }
+            }
+        }
+        
+        // Fallback: use connector name directly with prefix if config is not available
+        return "connect-" + connectorName;
+    }
+
+    /**
+     * Gets the maximum number of tasks configured for a connector.
+     * Defaults to 1 if not specified or configuration is not available.
+     */
+    protected int getTasksMaxForConnector(String connectorName) {
+        if (configSnapshot != null) {
+            Map<String, String> connectorConfig = configSnapshot.connectorConfig(connectorName);
+            if (connectorConfig != null) {
+                String tasksMaxStr = connectorConfig.get("tasks.max");
+                if (tasksMaxStr != null && !tasksMaxStr.isEmpty()) {
+                    try {
+                        return Integer.parseInt(tasksMaxStr);
+                    } catch (NumberFormatException e) {
+                        log.warn("Invalid tasks.max value '{}' for connector '{}', defaulting to 1", 
+                                tasksMaxStr, connectorName);
+                    }
+                }
+            }
+        }
+        return 1; // Default value from ConnectorConfig.TASKS_MAX_DEFAULT
+    }
+
+    /**
+     * Assigns connectors for a single consumer group ensuring per-consumer balance.
+     */
+    private void assignConnectorsWithGlobalBalance(List<WorkerLoad> workerAssignment, List<String> connectors) {
+        if (connectors.isEmpty()) {
+            return;
+        }
+
+        String consumerGroup = extractConsumerFromConnector(connectors.get(0));
+        log.debug("Assigning {} connectors for consumer group '{}': {}", 
+                connectors.size(), consumerGroup, connectors);
+
+        // Log tasks.max configuration for each connector
+        for (String connector : connectors) {
+            int tasksMax = getTasksMaxForConnector(connector);
+            log.debug("Connector '{}' configured with tasks.max={}", connector, tasksMax);
+        }
+
+        // Sort workers by current connector load (ascending)
+        workerAssignment.sort(WorkerLoad.connectorComparator());
+
+        // Track current connector assignments per worker for this consumer
+        Map<String, Integer> currentConnectorCount = new HashMap<>();
+        for (WorkerLoad worker : workerAssignment) {
+            long count = worker.connectors().stream()
+                    .filter(c -> extractConsumerFromConnector(c).equals(consumerGroup))
+                    .count();
+            currentConnectorCount.put(worker.worker(), (int) count);
+        }
+
+        // Assign connectors round-robin style with balance constraints
+        for (String connector : connectors) {
+            // Find the worker with minimum connectors for this consumer group
+            WorkerLoad targetWorker = workerAssignment.stream()
+                    .min(Comparator.comparingInt(w -> currentConnectorCount.get(w.worker())))
+                    .orElse(workerAssignment.get(0));
+
+            log.debug("Assigning connector {} to worker {}", connector, targetWorker.worker());
+            targetWorker.assign(connector);
+            currentConnectorCount.put(targetWorker.worker(), 
+                    currentConnectorCount.get(targetWorker.worker()) + 1);
+        }
+    }
+
+    /**
+     * Assigns tasks for a single consumer group ensuring per-consumer balance.
+     */
+    private void assignTasksWithGlobalBalance(List<WorkerLoad> workerAssignment, List<ConnectorTaskId> tasks) {
+        if (tasks.isEmpty()) {
+            return;
+        }
+
+        String consumerGroup = extractConsumerFromConnector(tasks.get(0).connector());
+        log.debug("Assigning {} tasks for consumer group '{}': {}", 
+                tasks.size(), consumerGroup, tasks);
+
+        // Sort workers by current task load (ascending)
+        workerAssignment.sort(WorkerLoad.taskComparator());
+
+        // Track current task assignments per worker for this consumer
+        Map<String, Integer> currentTaskCount = new HashMap<>();
+        for (WorkerLoad worker : workerAssignment) {
+            long count = worker.tasks().stream()
+                    .filter(t -> extractConsumerFromConnector(t.connector()).equals(consumerGroup))
+                    .count();
+            currentTaskCount.put(worker.worker(), (int) count);
+        }
+
+        // Assign tasks round-robin style with balance constraints
+        for (ConnectorTaskId task : tasks) {
+            // Find the worker with minimum tasks for this consumer group
+            WorkerLoad targetWorker = workerAssignment.stream()
+                    .min(Comparator.comparingInt(w -> currentTaskCount.get(w.worker())))
+                    .orElse(workerAssignment.get(0));
+
+            log.debug("Assigning task {} to worker {}", task, targetWorker.worker());
+            targetWorker.assign(task);
+            currentTaskCount.put(targetWorker.worker(), 
+                    currentTaskCount.get(targetWorker.worker()) + 1);
+        }
+    }
+
+    @Override
+    protected ClusterAssignment performTaskAssignment(
+            ClusterConfigState configSnapshot,
+            int lastCompletedGenerationId,
+            int currentGenerationId,
+            Map<String, ConnectorsAndTasks> memberAssignments
+    ) {
+        log.info("Performing global balance task assignment for generation {}", currentGenerationId);
+
+        this.configSnapshot = configSnapshot;
+        Set<String> configuredConnectors = new TreeSet<>(configSnapshot.connectors());
+        Set<ConnectorTaskId> configuredTasks = configuredConnectors.stream()
+                .flatMap(connector -> configSnapshot.tasks(connector).stream())
+                .collect(Collectors.toSet());
+        log.debug("Total configured connectors: {}, Total configured tasks: {}", 
+                configuredConnectors.size(), configuredTasks.size());
+
+        GlobalBalanceTaskAssignorScenarioType balanceScenarioType = getTypeOfTaskBalanceScenario(
+                memberAssignments, configuredConnectors, configuredTasks);
+        log.info("Detected balance scenario type: {}", balanceScenarioType);
+
+
+        List<WorkerLoad> workerLoads = memberAssignments.entrySet().stream()
+                .map(entry -> new WorkerLoad.Builder(entry.getKey())
+                        .with(entry.getValue().connectors(), entry.getValue().tasks())
+                        .build())
+                .collect(Collectors.toList());
+        log.debug("Created {} worker loads for assignment", workerLoads.size());
+
+        if (balanceScenarioType == GlobalBalanceTaskAssignorScenarioType.INITIAL_CONNECTOR_ALLOCATION) {
+            return handleInitialConnectorAllocation(memberAssignments, workerLoads, configuredConnectors, configuredTasks);
+
+        } else if (balanceScenarioType == GlobalBalanceTaskAssignorScenarioType.WORKER_SCALE_DOWN || balanceScenarioType == GlobalBalanceTaskAssignorScenarioType.WORKER_CHANGED) {
+            return handleWorkerScaleDownOrChanged(configSnapshot, memberAssignments, configuredConnectors, configuredTasks);
+
+        } else if (balanceScenarioType == GlobalBalanceTaskAssignorScenarioType.WORKER_SCALE_UP) {
+            return handleWorkerScaleUp(configSnapshot, lastCompletedGenerationId, currentGenerationId, memberAssignments, configuredConnectors, configuredTasks);
+
+        } else {
+            return handleOtherScenario(configSnapshot, lastCompletedGenerationId, currentGenerationId, memberAssignments, configuredConnectors, configuredTasks);
+        }
+    }
+
+    /**
+     * Handles initial connector allocation scenario.
+     * This scenario occurs when new connectors/tasks are being deployed to the cluster
+     * and need to be assigned for the first time, ensuring global balance requirements.
+     */
+    private ClusterAssignment handleInitialConnectorAllocation(
+            Map<String, ConnectorsAndTasks> memberAssignments,
+            List<WorkerLoad> workerLoads,
+            Set<String> configuredConnectors,
+            Set<ConnectorTaskId> configuredTasks) {
+        
+        log.info("Handling initial connector allocation scenario");
+
+        // Determine if this is a completely empty cluster or new consumer groups being added
+        boolean isCompletelyEmptyCluster = memberAssignments.values().stream()
+                .allMatch(assignment -> assignment.connectors().isEmpty() && assignment.tasks().isEmpty());
+        
+        if (isCompletelyEmptyCluster) {
+            log.debug("Completely empty cluster - clearing all assignments for fresh start");
+            for (WorkerLoad worker : workerLoads) {
+                worker.connectors().clear();
+                worker.tasks().clear();
+            }
+        }
+        
+        // New consumer groups, assign the new (unassigned) connectors and tasks
+        Set<String> currentlyAssignedConnectors = memberAssignments.values().stream()
+                .flatMap(assignment -> assignment.connectors().stream())
+                .collect(Collectors.toSet());
+        
+        Set<ConnectorTaskId> currentlyAssignedTasks = memberAssignments.values().stream()
+                .flatMap(assignment -> assignment.tasks().stream())
+                .collect(Collectors.toSet());
+        
+        Set<String> newConnectors = configuredConnectors.stream()
+                .filter(connector -> !currentlyAssignedConnectors.contains(connector))
+                .collect(Collectors.toSet());
+        
+        Set<ConnectorTaskId> newTasks = configuredTasks.stream()
+                .filter(task -> !currentlyAssignedTasks.contains(task))
+                .collect(Collectors.toSet());
+        
+        log.debug("Assigning {} new connectors and {} new tasks using Scenario 1 logic", 
+                newConnectors.size(), newTasks.size());
+        
+        assignConnectors(workerLoads, newConnectors);
+        assignTasks(workerLoads, newTasks);
+        
+        // Build the cluster assignment from balanced allocation
+        Map<String, Collection<String>> allConnectorAssignments = workerLoads.stream()
+                .collect(Collectors.toMap(
+                        WorkerLoad::worker,
+                        WorkerLoad::connectors
+                ));
+        
+        Map<String, Collection<ConnectorTaskId>> allTaskAssignments = workerLoads.stream()
+                .collect(Collectors.toMap(
+                        WorkerLoad::worker,
+                        WorkerLoad::tasks
+                ));
+        
+        // Calculate newly assigned connectors and tasks (what was just assigned in this round)
+        Map<String, Collection<String>> newlyAssignedConnectors = new HashMap<>();
+        Map<String, Collection<ConnectorTaskId>> newlyAssignedTasks = new HashMap<>();
+        
+        for (WorkerLoad worker : workerLoads) {
+            String workerId = worker.worker();
+            
+            // Find newly assigned connectors for this worker
+            Collection<String> workerNewConnectors = worker.connectors().stream()
+                    .filter(newConnectors::contains)
+                    .collect(Collectors.toList());
+            if (!workerNewConnectors.isEmpty()) {
+                newlyAssignedConnectors.put(workerId, workerNewConnectors);
+            }
+            
+            // Find newly assigned tasks for this worker
+            Collection<ConnectorTaskId> workerNewTasks = worker.tasks().stream()
+                    .filter(newTasks::contains)
+                    .collect(Collectors.toList());
+            if (!workerNewTasks.isEmpty()) {
+                newlyAssignedTasks.put(workerId, workerNewTasks);
+            }
+        }
+        
+        log.debug("Global balance assignment complete - newly assigned connectors: {}, newly assigned tasks: {}", 
+                newlyAssignedConnectors, newlyAssignedTasks);
+        log.debug("Total assignments after balance - all connectors: {}, all tasks: {}", 
+                allConnectorAssignments, allTaskAssignments);
+        
+        // Verify and log the balance achieved
+        //logBalanceVerification(workerLoads, newConnectors, newTasks);
+        
+        // Update previousMembers for next rebalance cycle
+        previousMembers = memberAssignments.keySet();
+        
+        // Return the globally balanced cluster assignment for Scenario 1
+        return new ClusterAssignment(
+                newlyAssignedConnectors,  // newly assigned connectors (only the new ones)
+                newlyAssignedTasks,       // newly assigned tasks (only the new ones)
+                Collections.emptyMap(),   // no revocations in initial assignment
+                Collections.emptyMap(),   // no revocations in initial assignment
+                allConnectorAssignments,  // all assigned connectors after this rebalance
+                allTaskAssignments        // all assigned tasks after this rebalance
+        );
+    }
+
+    /**
+     * Handles worker scale down and worker changed scenarios.
+     * Both scenarios follow the same logic: redistribute only unassigned work from removed workers
+     * while preserving existing assignments on remaining workers.
+     */
+    private ClusterAssignment handleWorkerScaleDownOrChanged(
+            ClusterConfigState configSnapshot,
+            Map<String, ConnectorsAndTasks> memberAssignments,
+            Set<String> configuredConnectors,
+            Set<ConnectorTaskId> configuredTasks) {
+        
+        log.info("Handling worker scale down or changed scenario");
+
+        Set<String> currentMembers = memberAssignments.keySet();
+        Set<String> removedWorkers = previousMembers.stream()
+                .filter(worker -> !currentMembers.contains(worker))
+                .collect(Collectors.toSet());
+        
+        log.info("Detected {} removed workers: {}", removedWorkers.size(), removedWorkers);
+        
+        // Find unassigned connectors and tasks from removed workers
+        Set<String> unassignedConnectors = configuredConnectors.stream()
+                .filter(connector -> {
+                    // Check if this connector is currently assigned to any remaining worker
+                    return memberAssignments.values().stream()
+                            .noneMatch(assignment -> assignment.connectors().contains(connector));
+                })
+                .collect(Collectors.toSet());
+        
+        Set<ConnectorTaskId> unassignedTasks = configuredTasks.stream()
+                .filter(task -> {
+                    // Check if this task is currently assigned to any remaining worker
+                    return memberAssignments.values().stream()
+                            .noneMatch(assignment -> assignment.tasks().contains(task));
+                })
+                .collect(Collectors.toSet());
+        
+        log.info("Found {} unassigned connectors and {} unassigned tasks from removed workers", 
+                unassignedConnectors.size(), unassignedTasks.size());
+        
+        // If there are no unassigned connectors/tasks, no rebalancing needed
+        if (unassignedConnectors.isEmpty() && unassignedTasks.isEmpty()) {
+            log.info("No unassigned work found. Current assignments are preserved.");
+            
+            // Build assignments from current state (no changes)
+            Map<String, Collection<String>> currentConnectorAssignments = memberAssignments.entrySet().stream()
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            entry -> new ArrayList<>(entry.getValue().connectors())
+                    ));
+            
+            Map<String, Collection<ConnectorTaskId>> currentTaskAssignments = memberAssignments.entrySet().stream()
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            entry -> new ArrayList<>(entry.getValue().tasks())
+                    ));
+            
+            // Update previousMembers for next rebalance cycle
+            previousMembers = currentMembers;
+            
+            return new ClusterAssignment(
+                    Collections.emptyMap(),       // no newly assigned connectors
+                    Collections.emptyMap(),       // no newly assigned tasks
+                    Collections.emptyMap(),       // no revocations needed
+                    Collections.emptyMap(),       // no revocations needed
+                    currentConnectorAssignments,  // all current assignments
+                    currentTaskAssignments        // all current assignments
+            );
+        }
+        
+        // Create WorkerLoad objects for remaining workers (preserving existing assignments)
+        List<WorkerLoad> remainingWorkerLoads = memberAssignments.entrySet().stream()
+                .map(entry -> new WorkerLoad.Builder(entry.getKey())
+                        .with(entry.getValue().connectors(), entry.getValue().tasks())
+                        .build())
+                .collect(Collectors.toList());
+        
+        log.debug("Remaining workers with preserved assignments: {}", 
+                remainingWorkerLoads.stream()
+                        .collect(Collectors.toMap(
+                                WorkerLoad::worker,
+                                w -> "connectors=" + w.connectors().size() + ", tasks=" + w.tasks().size()
+                        )));
+        
+        // Assign only the unassigned connectors and tasks using global balance
+        assignConnectors(remainingWorkerLoads, unassignedConnectors);
+        assignTasks(remainingWorkerLoads, unassignedTasks);
+        
+        // Build the cluster assignment
+        Map<String, Collection<String>> finalConnectorAssignments = remainingWorkerLoads.stream()
+                .collect(Collectors.toMap(
+                        WorkerLoad::worker,
+                        WorkerLoad::connectors
+                ));
+        
+        Map<String, Collection<ConnectorTaskId>> finalTaskAssignments = remainingWorkerLoads.stream()
+                .collect(Collectors.toMap(
+                        WorkerLoad::worker,
+                        WorkerLoad::tasks
+                ));
+        
+        // Calculate newly assigned connectors and tasks (only the unassigned ones)
+        Map<String, Collection<String>> scaleDownNewConnectors = new HashMap<>();
+        Map<String, Collection<ConnectorTaskId>> scaleDownNewTasks = new HashMap<>();
+        
+        for (WorkerLoad worker : remainingWorkerLoads) {
+            String workerId = worker.worker();
+            
+            // Find newly assigned connectors for this worker
+            Collection<String> workerNewConnectors = worker.connectors().stream()
+                    .filter(unassignedConnectors::contains)
+                    .collect(Collectors.toList());
+            if (!workerNewConnectors.isEmpty()) {
+                scaleDownNewConnectors.put(workerId, workerNewConnectors);
+            }
+            
+            // Find newly assigned tasks for this worker
+            Collection<ConnectorTaskId> workerNewTasks = worker.tasks().stream()
+                    .filter(unassignedTasks::contains)
+                    .collect(Collectors.toList());
+            if (!workerNewTasks.isEmpty()) {
+                scaleDownNewTasks.put(workerId, workerNewTasks);
+            }
+        }
+        
+        log.debug("Scale down rebalance complete - newly assigned connectors: {}, newly assigned tasks: {}", 
+                scaleDownNewConnectors, scaleDownNewTasks);
+        
+        // Verify and log the balance achieved
+        //logBalanceVerification(remainingWorkerLoads, unassignedConnectors, unassignedTasks);
+        
+        // Update previousMembers for next rebalance cycle
+        previousMembers = currentMembers;
+        
+        // Return the cluster assignment for worker scale down
+        return new ClusterAssignment(
+                scaleDownNewConnectors,   // newly assigned connectors (only from removed workers)
+                scaleDownNewTasks,        // newly assigned tasks (only from removed workers)
+                Collections.emptyMap(),   // no revocations needed (workers already gone)
+                Collections.emptyMap(),   // no revocations needed (workers already gone)
+                finalConnectorAssignments,  // all assigned connectors after rebalance
+                finalTaskAssignments        // all assigned tasks after rebalance
+        );
+    }
+
+    /**
+     * Handles worker scale up scenario.
+     * This scenario occurs when new workers are added to the cluster and existing
+     * assignments need to be rebalanced to utilize the new capacity while maintaining
+     * strict balance requirements.
+     */
+    private ClusterAssignment handleWorkerScaleUp(
+            ClusterConfigState configSnapshot,
+            int lastCompletedGenerationId,
+            int currentGenerationId,
+            Map<String, ConnectorsAndTasks> memberAssignments,
+            Set<String> configuredConnectors,
+            Set<ConnectorTaskId> configuredTasks) {
+        
+        log.info("Handling worker scale up scenario");
+
+        Set<String> currentMembers = memberAssignments.keySet();
+        Set<String> addedWorkers = currentMembers.stream()
+                .filter(worker -> !previousMembers.contains(worker))
+                .collect(Collectors.toSet());
+        
+        log.info("Detected {} added workers: {}", addedWorkers.size(), addedWorkers);
+
+        // Create WorkerLoad objects from current assignments
+        List<WorkerLoad> allWorkerLoads = memberAssignments.entrySet().stream()
+                .map(entry -> new WorkerLoad.Builder(entry.getKey())
+                        .with(entry.getValue().connectors(), entry.getValue().tasks())
+                        .build())
+                .collect(Collectors.toList());
+
+        int totalWorkers = allWorkerLoads.size();
+        log.debug("Total workers after scale up: {}", totalWorkers);
+
+        // Group current connectors and tasks by consumer
+        Map<String, List<String>> connectorsByConsumer = allWorkerLoads.stream()
+                .flatMap(worker -> worker.connectors().stream())
+                .collect(Collectors.groupingBy(this::extractConsumerFromConnector));
+
+        Map<String, List<ConnectorTaskId>> tasksByConsumer = allWorkerLoads.stream()
+                .flatMap(worker -> worker.tasks().stream())
+                .collect(Collectors.groupingBy(task -> extractConsumerFromConnector(task.connector())));
+
+        // Sort consumers by task count (descending) to prioritize highest task count consumers
+        List<String> sortedConsumers = tasksByConsumer.keySet().stream()
+                .sorted((consumer1, consumer2) -> {
+                    int tasks1 = tasksByConsumer.get(consumer1).size();
+                    int tasks2 = tasksByConsumer.get(consumer2).size();
+                    if (tasks1 != tasks2) {
+                        return Integer.compare(tasks2, tasks1); // Descending by task count
+                    }
+                    // If task counts are equal, sort by tasks.max (descending)
+                    int tasksMax1 = getMaxTasksForConsumerGroup(consumer1, connectorsByConsumer);
+                    int tasksMax2 = getMaxTasksForConsumerGroup(consumer2, connectorsByConsumer);
+                    return Integer.compare(tasksMax2, tasksMax1);
+                })
+                .collect(Collectors.toList());
+
+        // Track which tasks and connectors will be revoked and reassigned
+        Map<String, Collection<String>> revokedConnectors = new HashMap<>();
+        Map<String, Collection<ConnectorTaskId>> revokedTasks = new HashMap<>();
+        Set<String> connectorsToRebalance = new HashSet<>();
+        Set<ConnectorTaskId> tasksToRebalance = new HashSet<>();
+
+        // Calculate current global balance to determine if rebalancing is needed
+        int totalTasks = allWorkerLoads.stream().mapToInt(worker -> worker.tasks().size()).sum();
+        int idealTasksPerWorker = totalTasks / totalWorkers;
+        
+        // Check if global balance is violated (max - min > 1)
+        int minLoad = allWorkerLoads.stream().mapToInt(worker -> worker.tasks().size()).min().orElse(0);
+        int maxLoad = allWorkerLoads.stream().mapToInt(worker -> worker.tasks().size()).max().orElse(0);
+        
+        boolean needsGlobalRebalancing = (maxLoad - minLoad) > 1;
+        
+        if (!needsGlobalRebalancing) {
+            log.debug("Global balance already achieved (max:{}, min:{}), no rebalancing needed", maxLoad, minLoad);
+        } else {
+            log.debug("Global balance violated (max:{}, min:{}), rebalancing needed", maxLoad, minLoad);
+            
+            // When global balance is violated, we need to move tasks from overloaded to underloaded workers
+            // Collect all tasks from overloaded workers for redistribution
+            List<WorkerLoad> sortedWorkers = allWorkerLoads.stream()
+                    .sorted((w1, w2) -> Integer.compare(w2.tasks().size(), w1.tasks().size()))
+                    .collect(Collectors.toList());
+            
+            for (WorkerLoad worker : sortedWorkers) {
+                int currentTasks = worker.tasks().size();
+                int targetTasks = idealTasksPerWorker + (totalTasks % totalWorkers > 0 ? 1 : 0);
+                int remainingExtra = totalTasks % totalWorkers;
+                if (remainingExtra > 0) remainingExtra--;
+                
+                if (currentTasks > targetTasks) {
+                    // Revoke excess tasks for redistribution
+                    List<ConnectorTaskId> excessTasks = new ArrayList<>(worker.tasks());
+                    List<ConnectorTaskId> tasksToRevoke = excessTasks.subList(targetTasks, excessTasks.size());
+                    
+                    revokedTasks.computeIfAbsent(worker.worker(), k -> new ArrayList<>()).addAll(tasksToRevoke);
+                    tasksToRebalance.addAll(tasksToRevoke);
+                    
+                    // Remove excess tasks from worker
+                    worker.tasks().removeAll(tasksToRevoke);
+                    
+                    // Also revoke corresponding connectors
+                    List<String> connectorsToRevoke = tasksToRevoke.stream()
+                            .map(task -> task.connector())
+                            .distinct()
+                            .collect(Collectors.toList());
+                    
+                    revokedConnectors.computeIfAbsent(worker.worker(), k -> new ArrayList<>()).addAll(connectorsToRevoke);
+                    connectorsToRebalance.addAll(connectorsToRevoke);
+                    worker.connectors().removeAll(connectorsToRevoke);
+                }
+            }
+        }
+
+        // Only rebalance consumer groups with task count > number of workers (original logic for non-global cases)
+        for (String consumer : sortedConsumers) {
+            List<ConnectorTaskId> consumerTasks = tasksByConsumer.get(consumer);
+            List<String> consumerConnectors = connectorsByConsumer.getOrDefault(consumer, Collections.emptyList());
+
+            if (consumerTasks.size() > totalWorkers) {
+                log.debug("Consumer '{}' has {} tasks > {} workers, triggering rebalance", 
+                        consumer, consumerTasks.size(), totalWorkers);
+
+                // Calculate current distribution for this consumer
+                Map<String, List<ConnectorTaskId>> currentTaskDistribution = new HashMap<>();
+                Map<String, List<String>> currentConnectorDistribution = new HashMap<>();
+                
+                for (WorkerLoad worker : allWorkerLoads) {
+                    currentTaskDistribution.put(worker.worker(), new ArrayList<>());
+                    currentConnectorDistribution.put(worker.worker(), new ArrayList<>());
+                }
+
+                // Populate current distributions
+                for (WorkerLoad worker : allWorkerLoads) {
+                    worker.tasks().stream()
+                            .filter(task -> extractConsumerFromConnector(task.connector()).equals(consumer))
+                            .forEach(task -> currentTaskDistribution.get(worker.worker()).add(task));
+                    
+                    worker.connectors().stream()
+                            .filter(connector -> extractConsumerFromConnector(connector).equals(consumer))
+                            .forEach(connector -> currentConnectorDistribution.get(worker.worker()).add(connector));
+                }
+
+                // Calculate ideal distribution
+                int idealConsumerTasksPerWorker = consumerTasks.size() / totalWorkers;
+                int extraTasks = consumerTasks.size() % totalWorkers;
+                int idealConnectorsPerWorker = consumerConnectors.size() / totalWorkers;
+                int extraConnectors = consumerConnectors.size() % totalWorkers;
+
+                // Identify tasks and connectors to revoke for rebalancing
+                for (Map.Entry<String, List<ConnectorTaskId>> entry : currentTaskDistribution.entrySet()) {
+                    String workerId = entry.getKey();
+                    List<ConnectorTaskId> workerTasks = entry.getValue();
+                    
+                    int targetTaskCount = idealConsumerTasksPerWorker + (extraTasks > 0 ? 1 : 0);
+                    if (extraTasks > 0) extraTasks--;
+                    
+                    if (workerTasks.size() > targetTaskCount) {
+                        List<ConnectorTaskId> tasksForRevocation = workerTasks.subList(targetTaskCount, workerTasks.size());
+                        
+                        revokedTasks.computeIfAbsent(workerId, k -> new ArrayList<>()).addAll(tasksForRevocation);
+                        tasksToRebalance.addAll(tasksForRevocation);
+                        
+                        // Remove revoked tasks from worker
+                        for (WorkerLoad worker : allWorkerLoads) {
+                            if (worker.worker().equals(workerId)) {
+                                tasksForRevocation.forEach(task -> worker.tasks().remove(task));
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // Reset extraConnectors for connector distribution
+                extraConnectors = consumerConnectors.size() % totalWorkers;
+                for (Map.Entry<String, List<String>> entry : currentConnectorDistribution.entrySet()) {
+                    String workerId = entry.getKey();
+                    List<String> workerConnectors = entry.getValue();
+                    
+                    int targetConnectorCount = idealConnectorsPerWorker + (extraConnectors > 0 ? 1 : 0);
+                    if (extraConnectors > 0) extraConnectors--;
+                    
+                    if (workerConnectors.size() > targetConnectorCount) {
+                        List<String> connectorsForRevocation = workerConnectors.subList(targetConnectorCount, workerConnectors.size());
+                        
+                        revokedConnectors.computeIfAbsent(workerId, k -> new ArrayList<>()).addAll(connectorsForRevocation);
+                        connectorsToRebalance.addAll(connectorsForRevocation);
+                        
+                        // Remove revoked connectors from worker
+                        for (WorkerLoad worker : allWorkerLoads) {
+                            if (worker.worker().equals(workerId)) {
+                                connectorsForRevocation.forEach(connector -> worker.connectors().remove(connector));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        log.debug("Rebalancing {} connectors and {} tasks across {} workers", 
+                connectorsToRebalance.size(), tasksToRebalance.size(), totalWorkers);
+
+        // Assign the revoked connectors and tasks using global balance
+        assignConnectors(allWorkerLoads, connectorsToRebalance);
+        assignTasks(allWorkerLoads, tasksToRebalance);
+
+        // Build final assignments
+        Map<String, Collection<String>> finalConnectorAssignments = allWorkerLoads.stream()
+                .collect(Collectors.toMap(
+                        WorkerLoad::worker,
+                        WorkerLoad::connectors
+                ));
+
+        Map<String, Collection<ConnectorTaskId>> finalTaskAssignments = allWorkerLoads.stream()
+                .collect(Collectors.toMap(
+                        WorkerLoad::worker,
+                        WorkerLoad::tasks
+                ));
+
+        // Calculate newly assigned connectors and tasks (what was just reassigned)
+        Map<String, Collection<String>> newlyAssignedConnectors = new HashMap<>();
+        Map<String, Collection<ConnectorTaskId>> newlyAssignedTasks = new HashMap<>();
+
+        for (WorkerLoad worker : allWorkerLoads) {
+            String workerId = worker.worker();
+            
+            // Find newly assigned connectors for this worker
+            Collection<String> workerNewConnectors = worker.connectors().stream()
+                    .filter(connectorsToRebalance::contains)
+                    .collect(Collectors.toList());
+            if (!workerNewConnectors.isEmpty()) {
+                newlyAssignedConnectors.put(workerId, workerNewConnectors);
+            }
+            
+            // Find newly assigned tasks for this worker
+            Collection<ConnectorTaskId> workerNewTasks = worker.tasks().stream()
+                    .filter(tasksToRebalance::contains)
+                    .collect(Collectors.toList());
+            if (!workerNewTasks.isEmpty()) {
+                newlyAssignedTasks.put(workerId, workerNewTasks);
+            }
+        }
+
+        log.debug("Scale up rebalance complete - newly assigned connectors: {}, newly assigned tasks: {}", 
+                newlyAssignedConnectors, newlyAssignedTasks);
+
+        // Verify and log the balance achieved
+        //logBalanceVerification(allWorkerLoads, connectorsToRebalance, tasksToRebalance);
+
+        // Update previousMembers for next rebalance cycle
+        previousMembers = currentMembers;
+
+        // Return the cluster assignment for worker scale up
+        return new ClusterAssignment(
+                newlyAssignedConnectors,    // newly assigned connectors (rebalanced ones)
+                newlyAssignedTasks,         // newly assigned tasks (rebalanced ones)
+                revokedConnectors,          // revoked connectors for rebalancing
+                revokedTasks,               // revoked tasks for rebalancing
+                finalConnectorAssignments, // all assigned connectors after rebalance
+                finalTaskAssignments       // all assigned tasks after rebalance
+        );
+    }
+
+    /**
+     * Handles other scenario including catch-all and configuration changes.
+     * This scenario triggers a full rebalance across all workers, connectors and tasks
+     * ensuring strict balance requirements are enforced.
+     */
+    private ClusterAssignment handleOtherScenario(
+            ClusterConfigState configSnapshot,
+            int lastCompletedGenerationId,
+            int currentGenerationId,
+            Map<String, ConnectorsAndTasks> memberAssignments,
+            Set<String> configuredConnectors,
+            Set<ConnectorTaskId> configuredTasks) {
+        
+        log.info("Handling other scenario - performing full rebalance across all connectors and tasks");
+
+        Set<String> currentMembers = memberAssignments.keySet();
+        
+        // Create fresh WorkerLoad objects for complete rebalancing
+        List<WorkerLoad> allWorkerLoads = currentMembers.stream()
+                .map(worker -> new WorkerLoad.Builder(worker).build())
+                .collect(Collectors.toList());
+
+        log.debug("Performing full rebalance across {} workers for {} connectors and {} tasks", 
+                allWorkerLoads.size(), configuredConnectors.size(), configuredTasks.size());
+
+        // Assign all configured connectors and tasks using global balance
+        assignConnectors(allWorkerLoads, configuredConnectors);
+        assignTasks(allWorkerLoads, configuredTasks);
+
+        // Build final assignments
+        Map<String, Collection<String>> finalConnectorAssignments = allWorkerLoads.stream()
+                .collect(Collectors.toMap(
+                        WorkerLoad::worker,
+                        WorkerLoad::connectors
+                ));
+
+        Map<String, Collection<ConnectorTaskId>> finalTaskAssignments = allWorkerLoads.stream()
+                .collect(Collectors.toMap(
+                        WorkerLoad::worker,
+                        WorkerLoad::tasks
+                ));
+
+        // For full rebalance, all assignments are considered "newly assigned"
+        Map<String, Collection<String>> newlyAssignedConnectors = new HashMap<>(finalConnectorAssignments);
+        Map<String, Collection<ConnectorTaskId>> newlyAssignedTasks = new HashMap<>(finalTaskAssignments);
+
+        // All existing assignments are considered "revoked" since this is a full rebalance
+        Map<String, Collection<String>> revokedConnectors = new HashMap<>();
+        Map<String, Collection<ConnectorTaskId>> revokedTasks = new HashMap<>();
+        
+        for (Map.Entry<String, ConnectorsAndTasks> entry : memberAssignments.entrySet()) {
+            String workerId = entry.getKey();
+            ConnectorsAndTasks assignment = entry.getValue();
+            
+            if (!assignment.connectors().isEmpty()) {
+                revokedConnectors.put(workerId, assignment.connectors());
+            }
+            if (!assignment.tasks().isEmpty()) {
+                revokedTasks.put(workerId, assignment.tasks());
+            }
+        }
+
+        log.debug("Full rebalance complete - all {} connectors and {} tasks reassigned across {} workers", 
+                configuredConnectors.size(), configuredTasks.size(), allWorkerLoads.size());
+
+        // Verify and log the balance achieved
+        //logBalanceVerification(allWorkerLoads, configuredConnectors, configuredTasks);
+
+        // Update previousMembers for next rebalance cycle
+        previousMembers = currentMembers;
+
+        // Return the cluster assignment for full rebalance
+        return new ClusterAssignment(
+                newlyAssignedConnectors,    // all connectors are newly assigned
+                newlyAssignedTasks,         // all tasks are newly assigned
+                revokedConnectors,          // previous assignments are revoked
+                revokedTasks,               // previous assignments are revoked
+                finalConnectorAssignments, // final state after full rebalance
+                finalTaskAssignments       // final state after full rebalance
+        );
+    }
+
+    /**
+     * Gets the maximum tasks.max value for connectors in a consumer group.
+     */
+    private int getMaxTasksForConsumerGroup(String consumer, Map<String, List<String>> connectorsByConsumer) {
+        List<String> connectors = connectorsByConsumer.getOrDefault(consumer, Collections.emptyList());
+        return connectors.stream()
+                .mapToInt(this::getTasksMaxForConnector)
+                .max()
+                .orElse(0);
+    }
+
+    private GlobalBalanceTaskAssignorScenarioType getTypeOfTaskBalanceScenario(
+            Map<String, ConnectorsAndTasks> memberAssignments,
+            Set<String> configuredConnectors,
+            Set<ConnectorTaskId> configuredTasks) {
+
+        // Initial Connector Allocation Check
+        Set<String> currentlyAssignedConnectors = memberAssignments.values().stream()
+                .flatMap(assignment -> assignment.connectors().stream())
+                .collect(Collectors.toSet());
+        Set<ConnectorTaskId> currentlyAssignedTasks = memberAssignments.values().stream()
+                .flatMap(assignment -> assignment.tasks().stream())
+                .collect(Collectors.toSet());
+        Set<String> newUnassignedConnectors = configuredConnectors.stream()
+                .filter(connector -> !currentlyAssignedConnectors.contains(connector))
+                .collect(Collectors.toSet());        
+        Set<ConnectorTaskId> newUnassignedTasks = configuredTasks.stream()
+                .filter(task -> !currentlyAssignedTasks.contains(task))
+                .collect(Collectors.toSet());
+        boolean hasNewWorkToAssign = !newUnassignedConnectors.isEmpty() || !newUnassignedTasks.isEmpty();
+        
+        // Check if this is the very first assignment (no previous members tracked)
+        if (previousMembers == null || previousMembers.isEmpty()) {
+            return GlobalBalanceTaskAssignorScenarioType.INITIAL_CONNECTOR_ALLOCATION;
+        }
+        
+        if (hasNewWorkToAssign) {
+            return GlobalBalanceTaskAssignorScenarioType.INITIAL_CONNECTOR_ALLOCATION;
+        }
+
+        Set<String> currentMembers = memberAssignments.keySet();
+
+        // Scale Down Check
+        boolean isfewerWorkers = currentMembers.size() < previousMembers.size();
+        if (isfewerWorkers) {
+            return GlobalBalanceTaskAssignorScenarioType.WORKER_SCALE_DOWN;
+        }
+
+        // Scale Up Check
+        boolean moreWorkers = currentMembers.size() > previousMembers.size();
+        if (moreWorkers) {
+            return GlobalBalanceTaskAssignorScenarioType.WORKER_SCALE_UP;
+        }
+
+        // Worker Change Check
+        boolean hasWorkersChanged = !currentMembers.containsAll(previousMembers) || !previousMembers.containsAll(currentMembers);
+        if (hasWorkersChanged) {
+            return GlobalBalanceTaskAssignorScenarioType.WORKER_CHANGED;
+        }
+
+        // Catch All
+        return GlobalBalanceTaskAssignorScenarioType.OTHER;
+    }
+
+    private enum GlobalBalanceTaskAssignorScenarioType {
+        /**  
+        SCENARIO: Initial Allocation new connector deployment
+        A new consumer group deployment with no pre-existing task assignments. 
+        Tasks are allocated evenly among all available worker nodes.
+            - Allocate equal number of tasks among all 5 available worker nodes
+            - Per-consumer task count difference ≤ 1
+            - Overall total tasks difference per worker ≤ 1
+        **/
+        INITIAL_CONNECTOR_ALLOCATION,
+
+        /**  SCENARIO: Worker Scale Up Event
+        Worker scale up event where 1 or more nodes are added to the cluster.
+            - At all times, task difference for each consumer group ≤ 1 among all workers
+            - Only trigger rebalance for consumer groups with task count > number of workers
+            - Allocate equal amount of tasks on each node (difference ≤ 1)
+            - Overall total tasks difference per worker ≤ 1
+            - Sort consumers by task.max count and prioritize highest task count consumers
+            - Revoke and move only the minimum required number of tasks to create balanced distribution
+        **/
+        WORKER_SCALE_UP,
+
+        /**  
+        SCENARIO: Worker Scale Down Event
+        Worker scale down event where 1 or more nodes are removed from the cluster.
+            - Rebalance only the unassigned tasks from removed workers
+            - Assume assigned tasks on remaining workers (W1, W2, W3) are already balanced
+            - Allocate among remaining nodes in a balanced way
+            - No task count difference > 1 for each consumer across all worker nodes
+            - Overall total tasks difference per worker ≤ 1
+            - Existing workload on W1, W2, W3 is preserved
+        **/
+        WORKER_SCALE_DOWN,
+
+                /**  
+        SCENARIO: Worker Changed Event
+        Worker changed event where 1 or more nodes are replaced during
+        SCHEDULED_REBALANCE_MAX_DELAY_MS (scheduled.rebalance.max.delay.ms) window.
+            - Behavior is identical to scale down event
+            - Rebalance only the unassigned tasks from changed workers to the new ones
+            - Remaining assigned tasks on existing workers are preserved
+        **/
+        WORKER_CHANGED,
+
+        /**  
+        SCENARIO: Catch All Scenario 
+        Consumer group changes, configuration changes and other unhandled scenarios.
+            - Trigger redeploy ensuring full rebalance for the cluster
+        **/
+        OTHER
+    }
+
+/**
+    private void logBalanceVerification(List<WorkerLoad> workerLoads, Set<String> newConnectors, Set<ConnectorTaskId> newTasks) {
+        log.info("=== Balance Verification ===");
+        log.info("Workers: {}, New Connectors: {}, New Tasks: {}", 
+                workerLoads.size(), newConnectors.size(), newTasks.size());
+        
+        // Log per-worker assignments
+        for (WorkerLoad worker : workerLoads) {
+            int totalConnectors = worker.connectors().size();
+            int totalTasks = worker.tasks().size();
+            
+            // Count new assignments for this worker
+            long newConnectorCount = worker.connectors().stream()
+                    .filter(newConnectors::contains)
+                    .count();
+            long newTaskCount = worker.tasks().stream()
+                    .filter(newTasks::contains)
+                    .count();
+            
+            log.info("Worker {}: Total Connectors={}, Total Tasks={}, New Connectors={}, New Tasks={}", 
+                    worker.worker(), totalConnectors, totalTasks, newConnectorCount, newTaskCount);
+        }
+        
+        // Verify per-consumer balance
+        Map<String, List<String>> connectorsByConsumer = workerLoads.stream()
+                .flatMap(worker -> worker.connectors().stream())
+                .filter(newConnectors::contains)
+                .collect(Collectors.groupingBy(this::extractConsumerFromConnector));
+                
+        Map<String, List<ConnectorTaskId>> tasksByConsumer = workerLoads.stream()
+                .flatMap(worker -> worker.tasks().stream())
+                .filter(newTasks::contains)
+                .collect(Collectors.groupingBy(task -> extractConsumerFromConnector(task.connector())));
+        
+        for (String consumer : connectorsByConsumer.keySet()) {
+            verifyPerConsumerBalance(consumer, workerLoads, connectorsByConsumer.get(consumer), 
+                    tasksByConsumer.getOrDefault(consumer, Collections.emptyList()));
+        }
+        
+        log.info("=== End Balance Verification ===");
+    }
+    
+    private void verifyPerConsumerBalance(String consumer, List<WorkerLoad> workerLoads, 
+                                         List<String> consumerConnectors, List<ConnectorTaskId> consumerTasks) {
+        Map<String, Integer> connectorCountPerWorker = new HashMap<>();
+        Map<String, Integer> taskCountPerWorker = new HashMap<>();
+        
+        // Initialize all workers with 0 counts
+        for (WorkerLoad worker : workerLoads) {
+            connectorCountPerWorker.put(worker.worker(), 0);
+            taskCountPerWorker.put(worker.worker(), 0);
+        }
+        
+        // Count connectors per worker for this consumer
+        for (WorkerLoad worker : workerLoads) {
+            long count = worker.connectors().stream()
+                    .filter(c -> extractConsumerFromConnector(c).equals(consumer))
+                    .count();
+            connectorCountPerWorker.put(worker.worker(), (int) count);
+        }
+        
+        // Count tasks per worker for this consumer
+        for (WorkerLoad worker : workerLoads) {
+            long count = worker.tasks().stream()
+                    .filter(t -> extractConsumerFromConnector(t.connector()).equals(consumer))
+                    .count();
+            taskCountPerWorker.put(worker.worker(), (int) count);
+        }
+        
+        int minConnectors = Collections.min(connectorCountPerWorker.values());
+        int maxConnectors = Collections.max(connectorCountPerWorker.values());
+        int minTasks = Collections.min(taskCountPerWorker.values());
+        int maxTasks = Collections.max(taskCountPerWorker.values());
+        
+        boolean connectorBalanceOk = (maxConnectors - minConnectors) <= 1;
+        boolean taskBalanceOk = (maxTasks - minTasks) <= 1;
+        
+        log.info("Consumer '{}': Connectors=[{}-{}] (diff={}), Tasks=[{}-{}] (diff={}), Balance: Connectors={}, Tasks={}", 
+                consumer, minConnectors, maxConnectors, maxConnectors - minConnectors,
+                minTasks, maxTasks, maxTasks - minTasks,
+                connectorBalanceOk ? "OK" : "VIOLATED", taskBalanceOk ? "OK" : "VIOLATED");
+                
+        if (!connectorBalanceOk || !taskBalanceOk) {
+            log.warn("BALANCE VIOLATION detected for consumer '{}'", consumer);
+            log.debug("Connector distribution: {}", connectorCountPerWorker);
+            log.debug("Task distribution: {}", taskCountPerWorker);
+        }
+    }
+**/
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -81,7 +81,8 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
                              ConfigBackingStore configStorage,
                              WorkerRebalanceListener listener,
                              ConnectProtocolCompatibility protocolCompatibility,
-                             int maxDelay) {
+                             int maxDelay,
+                             boolean enableGlobalBalanceTaskAssignor) {
         super(config,
               logContext,
               client,
@@ -96,7 +97,9 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
         this.listener = listener;
         this.rejoinRequested = false;
         this.protocolCompatibility = protocolCompatibility;
-        this.incrementalAssignor = new IncrementalCooperativeAssignor(logContext, time, maxDelay);
+        this.incrementalAssignor = enableGlobalBalanceTaskAssignor
+                ? new GlobalBalanceTaskAssignor(logContext, time, maxDelay)
+                : new IncrementalCooperativeAssignor(logContext, time, maxDelay);
         this.eagerAssignor = new EagerAssignor(logContext);
         this.currentConnectProtocol = protocolCompatibility;
         this.coordinatorDiscoveryTimeoutMs = config.heartbeatIntervalMs;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -135,7 +135,8 @@ public class WorkerGroupMember {
                     configStorage,
                     listener,
                     ConnectProtocolCompatibility.compatibility(config.getString(DistributedConfig.CONNECT_PROTOCOL_CONFIG)),
-                    config.getInt(DistributedConfig.SCHEDULED_REBALANCE_MAX_DELAY_MS_CONFIG));
+                    config.getInt(DistributedConfig.SCHEDULED_REBALANCE_MAX_DELAY_MS_CONFIG),
+                    config.getBoolean(DistributedConfig.ENABLE_GLOBAL_BALANCE_TASK_ASSIGNOR_CONFIG));
 
             AppInfoParser.registerAppInfo(JMX_PREFIX, clientId, metrics, time.milliseconds());
             log.debug("Connect group member created");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/GlobalBalanceTaskAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/GlobalBalanceTaskAssignorTest.java
@@ -1,0 +1,869 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.distributed;
+
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor.ClusterAssignment;
+import org.apache.kafka.connect.runtime.distributed.WorkerCoordinator.ConnectorsAndTasks;
+import org.apache.kafka.connect.runtime.distributed.WorkerCoordinator.WorkerLoad;
+import org.apache.kafka.connect.storage.ClusterConfigState;
+import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GlobalBalanceTaskAssignorTest {
+    private static final Logger log = LoggerFactory.getLogger(GlobalBalanceTaskAssignorTest.class);
+
+    private LogContext logContext;
+    private MockTime time;
+    private ClusterConfigState configState;
+
+    /**
+     * Helper method to create connector configurations matching the MD file scenarios
+     */
+    private ClusterConfigState createConfigState() {
+        Map<String, Map<String, String>> connectorConfigs = new HashMap<>();
+        Map<String, Integer> taskCounts = new HashMap<>();
+        
+        // C1: 18 tasks
+        for (int i = 1; i <= 18; i++) {
+            Map<String, String> config = new HashMap<>();
+            config.put("name", "C1-connector" + i);
+            config.put("tasks.max", "1");
+            connectorConfigs.put("C1-connector" + i, config);
+            taskCounts.put("C1-connector" + i, 1);  // Each connector has 1 task
+        }
+        
+        // C2: 11 tasks
+        for (int i = 1; i <= 11; i++) {
+            Map<String, String> config = new HashMap<>();
+            config.put("name", "C2-connector" + i);
+            config.put("tasks.max", "1");
+            connectorConfigs.put("C2-connector" + i, config);
+            taskCounts.put("C2-connector" + i, 1);  // Each connector has 1 task
+        }
+        
+        // C3: 7 tasks
+        for (int i = 1; i <= 7; i++) {
+            Map<String, String> config = new HashMap<>();
+            config.put("name", "C3-connector" + i);
+            config.put("tasks.max", "1");
+            connectorConfigs.put("C3-connector" + i, config);
+            taskCounts.put("C3-connector" + i, 1);  // Each connector has 1 task
+        }
+        
+        // C4, C5, C6: 4 tasks each
+        for (String consumer : Arrays.asList("C4", "C5", "C6")) {
+            for (int i = 1; i <= 4; i++) {
+                Map<String, String> config = new HashMap<>();
+                config.put("name", consumer + "-connector" + i);
+                config.put("tasks.max", "1");
+                connectorConfigs.put(consumer + "-connector" + i, config);
+                taskCounts.put(consumer + "-connector" + i, 1);  // Each connector has 1 task
+            }
+        }
+        
+        // C7, C8: 3 tasks each
+        for (String consumer : Arrays.asList("C7", "C8")) {
+            for (int i = 1; i <= 3; i++) {
+                Map<String, String> config = new HashMap<>();
+                config.put("name", consumer + "-connector" + i);
+                config.put("tasks.max", "1");
+                connectorConfigs.put(consumer + "-connector" + i, config);
+                taskCounts.put(consumer + "-connector" + i, 1);  // Each connector has 1 task
+            }
+        }
+        
+        // C9-C14: 1 task each
+        for (String consumer : Arrays.asList("C9", "C10", "C11", "C12", "C13", "C14")) {
+            Map<String, String> config = new HashMap<>();
+            config.put("name", consumer + "-connector1");
+            config.put("tasks.max", "1");
+            connectorConfigs.put(consumer + "-connector1", config);
+            taskCounts.put(consumer + "-connector1", 1);  // Each connector has 1 task
+        }
+        
+        return new ClusterConfigState(
+                1L,
+                null,
+                taskCounts,       // connectorTaskCounts (tasks per connector)
+                connectorConfigs, // connectorConfigs
+                Collections.emptyMap(),  // connectorTargetStates
+                Collections.emptyMap(),  // taskConfigs
+                Collections.emptyMap(),  // connectorTaskCountRecords
+                Collections.emptyMap(),  // connectorTaskConfigGenerations
+                Collections.emptySet(),  // connectorsPendingFencing
+                Collections.emptySet()   // inconsistentConnectors
+        );
+    }
+
+    /**
+     * Scenario 1: Initial Allocation (Starting Unassigned State)
+     * 
+     * Tests the initial allocation of 60 tasks across 5 workers.
+     * Expected: Each worker gets 12 tasks with global balance difference ≤ 1
+     */
+    @Test
+    public void testScenario1InitialAllocation() {
+        logContext = new LogContext();
+        time = new MockTime();
+        configState = createConfigState();
+        
+        GlobalBalanceTaskAssignor assignor = new GlobalBalanceTaskAssignor(logContext, time, 0);
+        assignor.configSnapshot = configState;
+
+        // Create 5 workers (W1-W5)
+        List<WorkerLoad> workers = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            workers.add(new WorkerLoad.Builder("W" + i).build());
+        }
+
+        // Get all connectors and tasks from config
+        List<String> connectors = new ArrayList<>(configState.connectors());
+        List<ConnectorTaskId> tasks = new ArrayList<>();
+        for (String connector : connectors) {
+            tasks.add(new ConnectorTaskId(connector, 0));
+        }
+
+        log.info("=== Scenario 1: Initial Allocation ===");
+        log.info("Total connectors: {}, Total tasks: {}, Workers: {}", 
+                connectors.size(), tasks.size(), workers.size());
+
+        // Perform assignment
+        assignor.assignConnectors(workers, connectors);
+        assignor.assignTasks(workers, tasks);
+
+        // Verify results
+        int totalAssignments = 0;
+        int minLoad = Integer.MAX_VALUE;
+        int maxLoad = 0;
+        
+        Map<String, Integer> workerLoads = new HashMap<>();
+        for (WorkerLoad worker : workers) {
+            int workerLoad = worker.tasksSize(); // Only count tasks for balance
+            totalAssignments += workerLoad;
+            minLoad = Math.min(minLoad, workerLoad);
+            maxLoad = Math.max(maxLoad, workerLoad);
+            workerLoads.put(worker.worker(), workerLoad);
+            
+            log.info("Worker {}: {} connectors + {} tasks = {} tasks counted", 
+                    worker.worker(), worker.connectorsSize(), worker.tasksSize(), workerLoad);
+        }
+
+        // Assertions
+        assertEquals("Total assignments mismatch", 60, totalAssignments);
+        assertTrue("Global balance violated: max(" + maxLoad + ") - min(" + minLoad + ") > 1", 
+                   maxLoad - minLoad <= 1);
+        
+        // Each worker should have 12 tasks (60/5)
+        for (int load : workerLoads.values()) {
+            assertTrue("Worker load " + load + " should be 12 ± 1", 
+                      Math.abs(load - 12) <= 1);
+        }
+        
+        log.info("✓ Scenario 1 PASSED: Global balance achieved (min={}, max={}, diff={})", 
+                minLoad, maxLoad, maxLoad - minLoad);
+    }
+
+    /**
+     * Scenario 2: Consumer Config Change / Redeployment
+     * 
+     * Tests that configuration changes maintain existing assignments (affinity preservation).
+     * Expected: No task movement, same distribution as Scenario 1
+     */
+    @Test
+    public void testScenario2ConfigChange() {
+        logContext = new LogContext();
+        time = new MockTime();
+        configState = createConfigState();
+        
+        GlobalBalanceTaskAssignor assignor = new GlobalBalanceTaskAssignor(logContext, time, 0);
+        assignor.configSnapshot = configState;
+
+        // Create 5 workers with pre-existing balanced assignments
+        List<WorkerLoad> workers = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            workers.add(new WorkerLoad.Builder("W" + i).build());
+        }
+
+        // Initial assignment
+        List<String> connectors = new ArrayList<>(configState.connectors());
+        List<ConnectorTaskId> tasks = new ArrayList<>();
+        for (String connector : connectors) {
+            tasks.add(new ConnectorTaskId(connector, 0));
+        }
+
+        assignor.assignConnectors(workers, connectors);
+        assignor.assignTasks(workers, tasks);
+
+        // Store initial assignment
+        Map<String, Integer> initialLoads = new HashMap<>();
+        for (WorkerLoad worker : workers) {
+            initialLoads.put(worker.worker(), worker.connectorsSize() + worker.tasksSize());
+        }
+
+        log.info("=== Scenario 2: Config Change (Affinity Preservation) ===");
+        log.info("Initial state preserved - no rebalancing needed");
+
+        // Verify no changes (in real scenario, this would be a no-op rebalance)
+        for (WorkerLoad worker : workers) {
+            int currentLoad = worker.connectorsSize() + worker.tasksSize();
+            log.info("Worker {}: {} total (unchanged)", worker.worker(), currentLoad);
+            assertEquals("Worker load should not change", 
+                        initialLoads.get(worker.worker()).intValue(), currentLoad);
+        }
+        
+        log.info("✓ Scenario 2 PASSED: Affinity preserved");
+    }
+
+    /**
+     * Scenario 3: Worker Scale Down Event
+     * 
+     * Tests scaling down from 5 workers to 3 workers (W4, W5 removed).
+     * Expected: Tasks redistributed evenly across 3 workers (20 tasks each)
+     */
+    @Test
+    public void testScenario3ScaleDown() {
+        logContext = new LogContext();
+        time = new MockTime();
+        configState = createConfigState();
+        
+        GlobalBalanceTaskAssignor assignor = new GlobalBalanceTaskAssignor(logContext, time, 0);
+        assignor.configSnapshot = configState;
+
+        // Create 3 workers (W1-W3) after scale down
+        List<WorkerLoad> workers = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            workers.add(new WorkerLoad.Builder("W" + i).build());
+        }
+
+        // Get all connectors and tasks
+        List<String> connectors = new ArrayList<>(configState.connectors());
+        List<ConnectorTaskId> tasks = new ArrayList<>();
+        for (String connector : connectors) {
+            tasks.add(new ConnectorTaskId(connector, 0));
+        }
+
+        log.info("=== Scenario 3: Scale Down (5 → 3 workers) ===");
+        log.info("Total connectors: {}, Total tasks: {}, Workers: {}", 
+                connectors.size(), tasks.size(), workers.size());
+
+        // Perform assignment
+        assignor.assignConnectors(workers, connectors);
+        assignor.assignTasks(workers, tasks);
+
+        // Verify results
+        int totalAssignments = 0;
+        int minLoad = Integer.MAX_VALUE;
+        int maxLoad = 0;
+        
+        for (WorkerLoad worker : workers) {
+            int workerLoad = worker.tasksSize(); // Only count tasks for balance
+            totalAssignments += workerLoad;
+            minLoad = Math.min(minLoad, workerLoad);
+            maxLoad = Math.max(maxLoad, workerLoad);
+            
+            log.info("Worker {}: {} connectors + {} tasks = {} tasks counted", 
+                    worker.worker(), worker.connectorsSize(), worker.tasksSize(), workerLoad);
+        }
+
+        // Assertions
+        assertEquals("Total assignments mismatch", 60, totalAssignments);
+        assertTrue("Global balance violated: max(" + maxLoad + ") - min(" + minLoad + ") > 1", 
+                   maxLoad - minLoad <= 1);
+        
+        // Each worker should have 20 tasks (60/3)
+        for (WorkerLoad worker : workers) {
+            int load = worker.tasksSize(); // Only count tasks for balance
+            assertTrue("Worker load " + load + " should be 20 ± 1", 
+                      Math.abs(load - 20) <= 1);
+        }
+        
+        log.info("✓ Scenario 3 PASSED: Scale down balanced (min={}, max={}, diff={})", 
+                minLoad, maxLoad, maxLoad - minLoad);
+    }
+
+    /**
+     * Scenario 4: Worker Scale Up Event
+     * 
+     * Tests scaling up from 3 workers to 6 workers (W4, W5, W6 added).
+     * Expected: Tasks redistributed evenly across 6 workers (10 tasks each)
+     */
+    @Test
+    public void testScenario4ScaleUp() {
+        logContext = new LogContext();
+        time = new MockTime();
+        configState = createConfigState();
+        
+        GlobalBalanceTaskAssignor assignor = new GlobalBalanceTaskAssignor(logContext, time, 0);
+        assignor.configSnapshot = configState;
+
+        // Create 6 workers (W1-W6) after scale up
+        List<WorkerLoad> workers = new ArrayList<>();
+        for (int i = 1; i <= 6; i++) {
+            workers.add(new WorkerLoad.Builder("W" + i).build());
+        }
+
+        // Get all connectors and tasks
+        List<String> connectors = new ArrayList<>(configState.connectors());
+        List<ConnectorTaskId> tasks = new ArrayList<>();
+        for (String connector : connectors) {
+            tasks.add(new ConnectorTaskId(connector, 0));
+        }
+
+        log.info("=== Scenario 4: Scale Up (3 → 6 workers) ===");
+        log.info("Total connectors: {}, Total tasks: {}, Workers: {}", 
+                connectors.size(), tasks.size(), workers.size());
+
+        // Perform assignment
+        assignor.assignConnectors(workers, connectors);
+        assignor.assignTasks(workers, tasks);
+
+        // Verify results
+        int totalAssignments = 0;
+        int minLoad = Integer.MAX_VALUE;
+        int maxLoad = 0;
+        
+        for (WorkerLoad worker : workers) {
+            int workerLoad = worker.tasksSize(); // Only count tasks for balance
+            totalAssignments += workerLoad;
+            minLoad = Math.min(minLoad, workerLoad);
+            maxLoad = Math.max(maxLoad, workerLoad);
+            
+            log.info("Worker {}: {} connectors + {} tasks = {} tasks counted", 
+                    worker.worker(), worker.connectorsSize(), worker.tasksSize(), workerLoad);
+        }
+
+        // Assertions
+        assertEquals("Total assignments mismatch", 60, totalAssignments);
+        assertTrue("Global balance violated: max(" + maxLoad + ") - min(" + minLoad + ") > 1", 
+                   maxLoad - minLoad <= 1);
+        
+        // Each worker should have 10 tasks (60/6)
+        for (WorkerLoad worker : workers) {
+            int load = worker.tasksSize(); // Only count tasks for balance
+            assertTrue("Worker load " + load + " should be 10 ± 1", 
+                      Math.abs(load - 10) <= 1);
+        }
+        
+        log.info("✓ Scenario 4 PASSED: Scale up balanced (min={}, max={}, diff={})", 
+                minLoad, maxLoad, maxLoad - minLoad);
+    }
+
+    /**
+     * Test per-consumer balance requirement
+     * 
+     * Verifies that for each consumer group, task count difference across workers ≤ 1
+     */
+    @Test
+    public void testPerConsumerBalance() {
+        logContext = new LogContext();
+        time = new MockTime();
+        configState = createConfigState();
+        
+        GlobalBalanceTaskAssignor assignor = new GlobalBalanceTaskAssignor(logContext, time, 0);
+        assignor.configSnapshot = configState;
+
+        // Create 5 workers
+        List<WorkerLoad> workers = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            workers.add(new WorkerLoad.Builder("W" + i).build());
+        }
+
+        // Get all connectors and tasks
+        List<String> connectors = new ArrayList<>(configState.connectors());
+        List<ConnectorTaskId> tasks = new ArrayList<>();
+        for (String connector : connectors) {
+            tasks.add(new ConnectorTaskId(connector, 0));
+        }
+
+        // Perform assignment
+        assignor.assignConnectors(workers, connectors);
+        assignor.assignTasks(workers, tasks);
+
+        log.info("=== Per-Consumer Balance Test ===");
+
+        // Verify per-consumer balance for each consumer group
+        Map<String, Map<String, Integer>> perConsumerCounts = new HashMap<>();
+        
+        for (WorkerLoad worker : workers) {
+            // Count connectors per consumer
+            for (String connector : worker.connectors()) {
+                String consumerGroup = assignor.extractConsumerFromConnector(connector);
+                perConsumerCounts.computeIfAbsent(consumerGroup, k -> new HashMap<>());
+                perConsumerCounts.get(consumerGroup).merge(worker.worker(), 1, Integer::sum);
+            }
+            
+            // Count tasks per consumer
+            for (ConnectorTaskId task : worker.tasks()) {
+                String consumerGroup = assignor.extractConsumerFromConnector(task.connector());
+                perConsumerCounts.computeIfAbsent(consumerGroup, k -> new HashMap<>());
+                perConsumerCounts.get(consumerGroup).merge(worker.worker(), 1, Integer::sum);
+            }
+        }
+
+        // Verify each consumer group has difference ≤ 1
+        for (Map.Entry<String, Map<String, Integer>> entry : perConsumerCounts.entrySet()) {
+            String consumer = entry.getKey();
+            Map<String, Integer> workerCounts = entry.getValue();
+            
+            int min = Collections.min(workerCounts.values());
+            int max = Collections.max(workerCounts.values());
+            
+            log.info("Consumer {}: distribution={}, min={}, max={}, diff={}", 
+                    consumer, workerCounts, min, max, max - min);
+            
+            assertTrue("Per-consumer balance violated for " + consumer + 
+                      ": max(" + max + ") - min(" + min + ") > 1", 
+                      max - min <= 1);
+        }
+        
+        log.info("✓ Per-Consumer Balance PASSED: All consumer groups balanced");
+    }
+
+    @Test
+    public void testConsumerGroupExtractionWithConfig() {
+        LogContext logContext = new LogContext();
+        MockTime time = new MockTime();
+        GlobalBalanceTaskAssignor assignor = new GlobalBalanceTaskAssignor(logContext, time, 0);
+
+        // Create a mock config state with connector configurations
+        Map<String, Map<String, String>> connectorConfigs = new HashMap<>();
+        
+        // S3 Sink connector config like the example provided
+        Map<String, String> s3SinkConfig = new HashMap<>();
+        s3SinkConfig.put("name", "s3-sink-ctv_usage");
+        s3SinkConfig.put("tasks.max", "1");
+        s3SinkConfig.put("connector.class", "io.confluent.connect.s3.S3SinkConnector");
+        connectorConfigs.put("s3-sink-ctv_usage", s3SinkConfig);
+
+        // Another connector config
+        Map<String, String> jdbcConnectorConfig = new HashMap<>();
+        jdbcConnectorConfig.put("name", "jdbc-source-users");
+        jdbcConnectorConfig.put("tasks.max", "3");
+        jdbcConnectorConfig.put("connector.class", "io.confluent.connect.jdbc.JdbcSourceConnector");
+        connectorConfigs.put("jdbc-source-users", jdbcConnectorConfig);
+
+        ClusterConfigState configState = new ClusterConfigState(
+                1L, // offset
+                null, // sessionKey
+                Collections.emptyMap(), // connectorTaskCounts
+                connectorConfigs, // connectorConfigs
+                Collections.emptyMap(), // connectorTargetStates (Map<String, TargetState>)
+                Collections.emptyMap(), // taskConfigs
+                Collections.emptyMap(), // connectorTaskCountRecords
+                Collections.emptyMap(), // connectorTaskConfigGenerations
+                Collections.emptySet(), // connectorsPendingFencing
+                Collections.emptySet()  // inconsistentConnectors
+        );
+
+        // Set the config state in the assignor
+        assignor.configSnapshot = configState;
+
+        // Test consumer group extraction using connector config
+        assertEquals("connect-s3-sink-ctv_usage", assignor.extractConsumerFromConnector("s3-sink-ctv_usage"));
+        assertEquals("connect-jdbc-source-users", assignor.extractConsumerFromConnector("jdbc-source-users"));
+
+        // Test tasks.max extraction
+        assertEquals(1, assignor.getTasksMaxForConnector("s3-sink-ctv_usage"));
+        assertEquals(3, assignor.getTasksMaxForConnector("jdbc-source-users"));
+        assertEquals(1, assignor.getTasksMaxForConnector("non-existent-connector")); // Default value
+
+        log.info("Consumer group extraction with config test passed");
+    }
+
+    /**
+     * Test Scenario 1: Initial Allocation New Consumer Group Deployment
+     * 
+     * Tests the complete performTaskAssignment method for initial allocation scenario.
+     * This verifies the scenario detection and proper handling through handleInitialConnectorAllocation.
+     */
+    @Test
+    public void testScenario1CompleteInitialAllocation() {
+        logContext = new LogContext();
+        time = new MockTime();
+        configState = createConfigState();
+        
+        GlobalBalanceTaskAssignor assignor = new GlobalBalanceTaskAssignor(logContext, time, 0);
+
+        // Create member assignments with 5 workers, all empty (no previous assignments)
+        Map<String, ConnectorsAndTasks> memberAssignments = new HashMap<>();
+        for (int i = 1; i <= 5; i++) {
+            memberAssignments.put("W" + i, new ConnectorsAndTasks.Builder().build());
+        }
+
+        log.info("=== Scenario 1 Complete Test: Initial Allocation ===");
+        log.info("5 workers, 60 total tasks, expecting 12 tasks per worker");
+
+        // Perform complete task assignment
+        ClusterAssignment assignment = assignor.performTaskAssignment(
+                configState, 0, 1, memberAssignments);
+
+        // Verify all connectors and tasks are assigned
+        int totalConnectors = assignment.allAssignedConnectors().values().stream()
+                .mapToInt(Collection::size).sum();
+        int totalTasks = assignment.allAssignedTasks().values().stream()
+                .mapToInt(Collection::size).sum();
+
+        assertEquals("All 60 connectors should be assigned", 60, totalConnectors);
+        assertEquals("All 60 tasks should be assigned", 60, totalTasks);
+
+        // Verify global balance
+        verifyGlobalBalance(assignment.allAssignedTasks(), 5, 60);
+        
+        // Verify per-consumer balance
+        verifyPerConsumerBalance(assignment.allAssignedTasks(), assignor);
+
+        log.info("✓ Scenario 1 Complete PASSED: Initial allocation with perfect balance");
+    }
+
+    /**
+     * Test Scenario 2: Worker Scale Down Event
+     * 
+     * Tests scaling down from 5 workers to 3 workers.
+     * This should preserve existing assignments and only redistribute unassigned work.
+     */
+    @Test
+    public void testScenario2CompleteWorkerScaleDown() {
+        logContext = new LogContext();
+        time = new MockTime();
+        configState = createConfigState();
+        
+        GlobalBalanceTaskAssignor assignor = new GlobalBalanceTaskAssignor(logContext, time, 0);
+
+        // First, create initial state with 5 workers
+        Map<String, ConnectorsAndTasks> initialMemberAssignments = new HashMap<>();
+        for (int i = 1; i <= 5; i++) {
+            initialMemberAssignments.put("W" + i, new ConnectorsAndTasks.Builder().build());
+        }
+
+        // Perform initial assignment to establish baseline
+        ClusterAssignment initialAssignment = assignor.performTaskAssignment(
+                configState, 0, 1, initialMemberAssignments);
+
+        // Simulate scale down: remove W4 and W5, preserve W1-W3 assignments
+        Map<String, ConnectorsAndTasks> scaleDownAssignments = new HashMap<>();
+        for (int i = 1; i <= 3; i++) {
+            String workerId = "W" + i;
+            Collection<String> workerConnectors = initialAssignment.allAssignedConnectors().get(workerId);
+            Collection<ConnectorTaskId> workerTasks = initialAssignment.allAssignedTasks().get(workerId);
+            scaleDownAssignments.put(workerId, new ConnectorsAndTasks.Builder()
+                    .with(workerConnectors, workerTasks).build());
+        }
+
+        log.info("=== Scenario 2 Complete Test: Worker Scale Down (5→3) ===");
+        log.info("Removed W4 and W5, expecting 20 tasks per remaining worker");
+
+        // Perform scale down assignment
+        ClusterAssignment scaleDownResult = assignor.performTaskAssignment(
+                configState, 1, 2, scaleDownAssignments);
+
+        // Verify all work is still assigned
+        int totalConnectors = scaleDownResult.allAssignedConnectors().values().stream()
+                .mapToInt(Collection::size).sum();
+        int totalTasks = scaleDownResult.allAssignedTasks().values().stream()
+                .mapToInt(Collection::size).sum();
+
+        assertEquals("All 60 connectors should still be assigned", 60, totalConnectors);
+        assertEquals("All 60 tasks should still be assigned", 60, totalTasks);
+
+        // Verify global balance with 3 workers
+        verifyGlobalBalance(scaleDownResult.allAssignedTasks(), 3, 60);
+
+        // Verify per-consumer balance
+        verifyPerConsumerBalance(scaleDownResult.allAssignedTasks(), assignor);
+
+        log.info("✓ Scenario 2 Complete PASSED: Scale down with balanced redistribution");
+    }
+
+    /**
+     * Test Scenario 3: Worker Scale Up Event
+     * 
+     * Tests scaling up from 3 workers to 6 workers.
+     * This should rebalance high-task consumers while maintaining balance requirements.
+     */
+    @Test
+    public void testScenario3CompleteWorkerScaleUp() {
+        logContext = new LogContext();
+        time = new MockTime();
+        configState = createConfigState();
+        
+        GlobalBalanceTaskAssignor assignor = new GlobalBalanceTaskAssignor(logContext, time, 0);
+
+        // First, establish baseline with 3 workers
+        Map<String, ConnectorsAndTasks> threeWorkerAssignments = new HashMap<>();
+        for (int i = 1; i <= 3; i++) {
+            threeWorkerAssignments.put("W" + i, new ConnectorsAndTasks.Builder().build());
+        }
+
+        ClusterAssignment threeWorkerResult = assignor.performTaskAssignment(
+                configState, 0, 1, threeWorkerAssignments);
+
+        // Simulate scale up: add W4, W5, W6 while preserving W1-W3 assignments
+        Map<String, ConnectorsAndTasks> scaleUpAssignments = new HashMap<>();
+        for (int i = 1; i <= 3; i++) {
+            String workerId = "W" + i;
+            Collection<String> workerConnectors = threeWorkerResult.allAssignedConnectors().get(workerId);
+            Collection<ConnectorTaskId> workerTasks = threeWorkerResult.allAssignedTasks().get(workerId);
+            scaleUpAssignments.put(workerId, new ConnectorsAndTasks.Builder()
+                    .with(workerConnectors, workerTasks).build());
+        }
+
+        // Add new workers W4, W5, W6 with empty assignments
+        for (int i = 4; i <= 6; i++) {
+            scaleUpAssignments.put("W" + i, new ConnectorsAndTasks.Builder().build());
+        }
+
+        log.info("=== Scenario 3 Complete Test: Worker Scale Up (3→6) ===");
+        log.info("Added W4, W5, W6, expecting 10 tasks per worker");
+
+        // Perform scale up assignment
+        ClusterAssignment scaleUpResult = assignor.performTaskAssignment(
+                configState, 1, 2, scaleUpAssignments);
+
+        // Verify all work is still assigned
+        int totalConnectors = scaleUpResult.allAssignedConnectors().values().stream()
+                .mapToInt(Collection::size).sum();
+        int totalTasks = scaleUpResult.allAssignedTasks().values().stream()
+                .mapToInt(Collection::size).sum();
+
+        assertEquals("All 60 connectors should still be assigned", 60, totalConnectors);
+        assertEquals("All 60 tasks should still be assigned", 60, totalTasks);
+
+        // Verify global balance with 6 workers
+        verifyGlobalBalance(scaleUpResult.allAssignedTasks(), 6, 60);
+
+        // Verify per-consumer balance
+        verifyPerConsumerBalance(scaleUpResult.allAssignedTasks(), assignor);
+
+        log.info("✓ Scenario 3 Complete PASSED: Scale up with balanced rebalancing");
+    }
+
+    /**
+     * Test Scenario 4: Catch All & Consumer Config Change / Update
+     * 
+     * Tests the OTHER scenario that triggers full rebalance.
+     * This should redistribute all work while maintaining balance requirements.
+     */
+    @Test
+    public void testScenario4CompleteOtherConfigChange() {
+        logContext = new LogContext();
+        time = new MockTime();
+        configState = createConfigState();
+        
+        GlobalBalanceTaskAssignor assignor = new GlobalBalanceTaskAssignor(logContext, time, 0);
+
+        // Create baseline assignment with 6 workers
+        Map<String, ConnectorsAndTasks> baselineAssignments = new HashMap<>();
+        for (int i = 1; i <= 6; i++) {
+            baselineAssignments.put("W" + i, new ConnectorsAndTasks.Builder().build());
+        }
+
+        ClusterAssignment baselineResult = assignor.performTaskAssignment(
+                configState, 0, 1, baselineAssignments);
+
+        // Simulate configuration change scenario - preserve worker set but trigger OTHER scenario
+        // This can happen due to connector config changes or other factors
+        Map<String, ConnectorsAndTasks> configChangeAssignments = new HashMap<>();
+        for (int i = 1; i <= 6; i++) {
+            String workerId = "W" + i;
+            Collection<String> workerConnectors = baselineResult.allAssignedConnectors().get(workerId);
+            Collection<ConnectorTaskId> workerTasks = baselineResult.allAssignedTasks().get(workerId);
+            configChangeAssignments.put(workerId, new ConnectorsAndTasks.Builder()
+                    .with(workerConnectors, workerTasks).build());
+        }
+
+        log.info("=== Scenario 4 Complete Test: Other/Config Change ===");
+        log.info("6 workers, triggering full rebalance, expecting 10 tasks per worker");
+
+        // Force OTHER scenario by manipulating the generation and ensuring it's not detected as other scenarios
+        // This simulates configuration changes that require full rebalance
+        ClusterAssignment configChangeResult = assignor.performTaskAssignment(
+                configState, 1, 3, configChangeAssignments);
+
+        // Verify all work is assigned
+        int totalConnectors = configChangeResult.allAssignedConnectors().values().stream()
+                .mapToInt(Collection::size).sum();
+        int totalTasks = configChangeResult.allAssignedTasks().values().stream()
+                .mapToInt(Collection::size).sum();
+
+        assertEquals("All 60 connectors should be assigned", 60, totalConnectors);
+        assertEquals("All 60 tasks should be assigned", 60, totalTasks);
+
+        // Verify global balance with 6 workers
+        verifyGlobalBalance(configChangeResult.allAssignedTasks(), 6, 60);
+
+        // Verify per-consumer balance
+        verifyPerConsumerBalance(configChangeResult.allAssignedTasks(), assignor);
+
+        log.info("✓ Scenario 4 Complete PASSED: Full rebalance with perfect balance");
+    }
+
+    /**
+     * Test Multi-Scenario Worker Lifecycle
+     * 
+     * Tests a complete lifecycle: Initial → Scale Down → Scale Up → Config Change
+     * This verifies that the assignor correctly handles scenario transitions.
+     */
+    @Test
+    public void testCompleteWorkerLifecycle() {
+        logContext = new LogContext();
+        time = new MockTime();
+        configState = createConfigState();
+        
+        GlobalBalanceTaskAssignor assignor = new GlobalBalanceTaskAssignor(logContext, time, 0);
+
+        log.info("=== Complete Worker Lifecycle Test ===");
+
+        // Phase 1: Initial allocation with 5 workers
+        Map<String, ConnectorsAndTasks> phase1Assignments = new HashMap<>();
+        for (int i = 1; i <= 5; i++) {
+            phase1Assignments.put("W" + i, new ConnectorsAndTasks.Builder().build());
+        }
+
+        ClusterAssignment phase1Result = assignor.performTaskAssignment(
+                configState, 0, 1, phase1Assignments);
+        
+        log.info("Phase 1 (Initial): 5 workers, 12 tasks each");
+        verifyGlobalBalance(phase1Result.allAssignedTasks(), 5, 60);
+
+        // Phase 2: Scale down to 3 workers (remove W4, W5)
+        Map<String, ConnectorsAndTasks> phase2Assignments = new HashMap<>();
+        for (int i = 1; i <= 3; i++) {
+            String workerId = "W" + i;
+            Collection<String> workerConnectors = phase1Result.allAssignedConnectors().getOrDefault(workerId, Collections.emptyList());
+            Collection<ConnectorTaskId> workerTasks = phase1Result.allAssignedTasks().getOrDefault(workerId, Collections.emptyList());
+            phase2Assignments.put(workerId, new ConnectorsAndTasks.Builder()
+                    .with(workerConnectors, workerTasks).build());
+        }
+
+        ClusterAssignment phase2Result = assignor.performTaskAssignment(
+                configState, 1, 2, phase2Assignments);
+
+        log.info("Phase 2 (Scale Down): 3 workers, 20 tasks each");
+        verifyGlobalBalance(phase2Result.allAssignedTasks(), 3, 60);
+
+        // Phase 3: Scale up to 6 workers (add W4, W5, W6)
+        Map<String, ConnectorsAndTasks> phase3Assignments = new HashMap<>();
+        for (int i = 1; i <= 3; i++) {
+            String workerId = "W" + i;
+            Collection<String> workerConnectors = phase2Result.allAssignedConnectors().getOrDefault(workerId, Collections.emptyList());
+            Collection<ConnectorTaskId> workerTasks = phase2Result.allAssignedTasks().getOrDefault(workerId, Collections.emptyList());
+            phase3Assignments.put(workerId, new ConnectorsAndTasks.Builder()
+                    .with(workerConnectors, workerTasks).build());
+        }
+        for (int i = 4; i <= 6; i++) {
+            phase3Assignments.put("W" + i, new ConnectorsAndTasks.Builder().build());
+        }
+
+        ClusterAssignment phase3Result = assignor.performTaskAssignment(
+                configState, 2, 3, phase3Assignments);
+
+        log.info("Phase 3 (Scale Up): 6 workers, 10 tasks each");
+        verifyGlobalBalance(phase3Result.allAssignedTasks(), 6, 60);
+
+        // Phase 4: Configuration change (full rebalance) - simulate by skipping generation
+        Map<String, ConnectorsAndTasks> phase4Assignments = new HashMap<>();
+        for (int i = 1; i <= 6; i++) {
+            String workerId = "W" + i;
+            Collection<String> workerConnectors = phase3Result.allAssignedConnectors().getOrDefault(workerId, Collections.emptyList());
+            Collection<ConnectorTaskId> workerTasks = phase3Result.allAssignedTasks().getOrDefault(workerId, Collections.emptyList());
+            phase4Assignments.put(workerId, new ConnectorsAndTasks.Builder()
+                    .with(workerConnectors, workerTasks).build());
+        }
+
+        ClusterAssignment phase4Result = assignor.performTaskAssignment(
+                configState, 3, 5, phase4Assignments);  // Skip generation to trigger OTHER scenario
+
+        log.info("Phase 4 (Config Change): 6 workers, 10 tasks each");
+        verifyGlobalBalance(phase4Result.allAssignedTasks(), 6, 60);
+
+        // Final verification
+        verifyPerConsumerBalance(phase4Result.allAssignedTasks(), assignor);
+
+        log.info("✓ Complete Lifecycle PASSED: All scenarios handled correctly");
+    }
+
+    /**
+     * Helper method to verify global balance requirements.
+     */
+    private void verifyGlobalBalance(Map<String, Collection<ConnectorTaskId>> taskAssignments, 
+                                   int expectedWorkers, int expectedTotalTasks) {
+        assertEquals("Worker count mismatch", expectedWorkers, taskAssignments.size());
+
+        int totalTasks = taskAssignments.values().stream().mapToInt(Collection::size).sum();
+        assertEquals("Total task count mismatch", expectedTotalTasks, totalTasks);
+
+        int minLoad = taskAssignments.values().stream().mapToInt(Collection::size).min().orElse(0);
+        int maxLoad = taskAssignments.values().stream().mapToInt(Collection::size).max().orElse(0);
+
+        assertTrue("Global balance violated: max(" + maxLoad + ") - min(" + minLoad + ") > 1", 
+                   maxLoad - minLoad <= 1);
+
+        int expectedTasksPerWorker = expectedTotalTasks / expectedWorkers;
+        for (Map.Entry<String, Collection<ConnectorTaskId>> entry : taskAssignments.entrySet()) {
+            int workerTasks = entry.getValue().size();
+            assertTrue("Worker " + entry.getKey() + " has " + workerTasks + " tasks, expected " + 
+                      expectedTasksPerWorker + " ± 1", 
+                      Math.abs(workerTasks - expectedTasksPerWorker) <= 1);
+        }
+    }
+
+    /**
+     * Helper method to verify per-consumer balance requirements.
+     */
+    private void verifyPerConsumerBalance(Map<String, Collection<ConnectorTaskId>> taskAssignments, 
+                                        GlobalBalanceTaskAssignor assignor) {
+        // Group tasks by consumer
+        Map<String, Map<String, Integer>> consumerTaskCounts = new HashMap<>();
+        
+        for (Map.Entry<String, Collection<ConnectorTaskId>> entry : taskAssignments.entrySet()) {
+            String workerId = entry.getKey();
+            for (ConnectorTaskId task : entry.getValue()) {
+                String consumer = assignor.extractConsumerFromConnector(task.connector());
+                consumerTaskCounts.computeIfAbsent(consumer, k -> new HashMap<>())
+                        .merge(workerId, 1, Integer::sum);
+            }
+        }
+
+        // Verify each consumer group has difference ≤ 1
+        for (Map.Entry<String, Map<String, Integer>> consumerEntry : consumerTaskCounts.entrySet()) {
+            String consumer = consumerEntry.getKey();
+            Map<String, Integer> workerCounts = consumerEntry.getValue();
+            
+            int minConsumerTasks = workerCounts.values().stream().mapToInt(Integer::intValue).min().orElse(0);
+            int maxConsumerTasks = workerCounts.values().stream().mapToInt(Integer::intValue).max().orElse(0);
+            
+            assertTrue("Consumer " + consumer + " balance violated: max(" + maxConsumerTasks + 
+                      ") - min(" + minConsumerTasks + ") > 1", 
+                      maxConsumerTasks - minConsumerTasks <= 1);
+        }
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorIncrementalTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorIncrementalTest.java
@@ -173,7 +173,8 @@ public class WorkerCoordinatorIncrementalTest {
                                                  configStorage,
                                                  rebalanceListener,
                                                  compatibility,
-                                                 rebalanceDelay);
+                                                 rebalanceDelay,
+                                                 false);
 
         configState1 = clusterConfigState(offset, 2, 4);
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorTest.java
@@ -158,7 +158,8 @@ public class WorkerCoordinatorTest {
                                                  configStorage,
                                                  rebalanceListener,
                                                  compatibility,
-                                                 0);
+                                                 0,
+                                                 false);
 
         configState1 = new ClusterConfigState(
                 4L,

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ group=org.apache.kafka
 #  - streams/quickstart/pom.xml
 #  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 #  - streams/quickstart/java/pom.xml
-version=3.6.2
+version=3.6.2-tl
 scalaVersion=2.13.11
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/kafka-libs-uploader.sh
+++ b/kafka-libs-uploader.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Uploads all kafka and connect jars in the current directory to S3
+# Usage: ./kafka-libs-uploader.sh
+# Script needs to be run in the top level directory of the kafka folder once built
+VERSION=3.2.6-tl
+S3_BASE_LOCATION=s3://ops.triplelift.net/public/kafka/${VERSION}/
+for jar in $(find . -name "*.jar" | grep -i connect-); do aws s3 cp $jar s3://ops.triplelift.net/public/kafka/${VERSION}/$(basename $jar); done
+for jar in $(find . -name "*.jar" | grep -i kafka); do aws s3 cp $jar s3://ops.triplelift.net/public/kafka/${VERSION}/$(basename $jar); done


### PR DESCRIPTION
This pull request introduces a new configuration option to enable a "Global Balance Task Assignor" for Kafka Connect in distributed mode. The assignor enforces strict per-consumer and global balance requirements, ensuring that the difference in task counts across workers never exceeds one, both for individual consumer groups and overall. The changes include documentation, configuration, implementation, and test updates to support this feature.

### Global Balance Task Assignor Feature

* Added the `enable.global.balance.task.assignor` configuration option to `DistributedConfig`, including documentation and a default value of `false`. This allows users to opt-in to the new assignor via configuration. [[1]](diffhunk://#diff-c52423b55cade16a51e523679afa4cc5701fd9bb67243eb4b6c5b4f93e1aa947R185-R195) [[2]](diffhunk://#diff-c52423b55cade16a51e523679afa4cc5701fd9bb67243eb4b6c5b4f93e1aa947R483-R487)
* Updated the construction of `WorkerCoordinator` and `WorkerGroupMember` to accept and pass the new configuration flag, enabling selection between the default incremental assignor and the new global balance assignor. [[1]](diffhunk://#diff-9075bf1ce4e8d878d16f25add001986e3e319cd5ce93290e4f10e4fd60e60155L84-R85) [[2]](diffhunk://#diff-04af17c5c2c84c02b8b970377d3d414776bd1d143d858eb2ef0a6934c19c9fe7L138-R139)
* Modified the logic in `WorkerCoordinator` to instantiate `GlobalBalanceTaskAssignor` when the flag is enabled, otherwise defaulting to `IncrementalCooperativeAssignor`.

### Documentation

* Added a new document `GLOBAL_BALANCE_TASK_ASSIGNOR_BEHAVIOR.md` explaining the behavior, scenarios, and guarantees of the global balance assignor, including detailed examples and balance verification.

### Testing and Code Quality

* Updated test setup methods in `WorkerCoordinatorTest` and `WorkerCoordinatorIncrementalTest` to include the new flag, ensuring backward compatibility and correct assignor selection in tests. [[1]](diffhunk://#diff-aff85ca35341f47a9c26841057a65a224c17652093c7aeba04ead6589e47799bL161-R162) [[2]](diffhunk://#diff-b815942c40606bbaa80696310607332754abce4801092923101d0957d9b3ba77L176-R177)
* Added checkstyle suppressions for complexity checks on `GlobalBalanceTaskAssignor.java`, reflecting the increased complexity in the new assignor logic.